### PR TITLE
feat: add canonical company record schema for issue #9

### DIFF
--- a/apps/company-data-agent/README.md
+++ b/apps/company-data-agent/README.md
@@ -1,0 +1,3 @@
+# company-data-agent
+
+Domain models and pipeline primitives for the Shenzhen company data collection workflow.

--- a/apps/company-data-agent/README.md
+++ b/apps/company-data-agent/README.md
@@ -1,3 +1,7 @@
 # company-data-agent
 
-Domain models and pipeline primitives for the Shenzhen company data collection workflow.
+深圳企业数据采集工作流的领域模型与流水线基础组件。
+
+## 文档
+
+- [Issue 9 实现说明](docs/issue-9-公司记录模型说明.md)

--- a/apps/company-data-agent/docs/issue-9-公司记录模型说明.md
+++ b/apps/company-data-agent/docs/issue-9-公司记录模型说明.md
@@ -1,0 +1,315 @@
+# Issue 9 实现说明：企业标准记录模型与字段约束
+
+本文档说明 `Issue #9` 已完成的实现内容，包括：
+
+1. 实现了什么
+2. 如何在代码中使用
+3. 如何验证当前实现
+
+当前实现位于 `apps/company-data-agent` 包中，核心文件如下：
+
+- `src/company_data_agent/models/company_record.py`
+- `tests/test_company_record.py`
+
+---
+
+## 一、这次实现了什么
+
+本次实现的目标是为后续企业数据采集流水线提供一个稳定、可复用、可验证的“标准企业记录结构”，避免不同阶段各自拼接字段、各自定义约束，导致数据结构漂移。
+
+### 1. 建立了统一的企业记录模型
+
+当前定义了两类主记录：
+
+- `PartialCompanyRecord`
+  作用：表示流水线中间阶段的企业记录。
+  适用场景：企业列表导入完成后、Qimingpian 补充后、网页抓取后，但尚未满足最终入库条件时。
+
+- `FinalCompanyRecord`
+  作用：表示已经满足最终持久化和下游消费条件的企业记录。
+  与 `PartialCompanyRecord` 的关键区别是：
+  - `id` 必须存在
+  - `profile_summary` 必须存在
+  - `profile_embedding` 必须存在
+  - `completeness_score` 必须存在
+  - `last_updated` 必须存在
+
+这种拆分避免了两个常见问题：
+
+- 中间态记录被错误地当成“可入库最终态”使用
+- 为了兼容中间态，把最终态字段也做成过于宽松，导致后续无法严格校验
+
+### 2. 建立了来源枚举
+
+实现了 `CompanySource` 枚举，用于统一记录企业信息的来源：
+
+- `master_list`
+- `qimingpian`
+- `website`
+- `pr_news`
+- `web_search`
+- `manual`
+
+作用是让 `sources` 字段不再依赖自由字符串，降低来源标记不一致的问题。
+
+### 3. 建立了关键人员的嵌套结构
+
+实现了：
+
+- `EducationRecord`
+- `KeyPersonnelRecord`
+
+用于约束 `key_personnel` 字段的数据形状，支持如下结构：
+
+```python
+[
+    {
+        "name": "张三",
+        "role": "CTO",
+        "education": [
+            {
+                "institution": "南方科技大学",
+                "degree": "PhD",
+                "year": 2020,
+                "field": "机器人学",
+            }
+        ],
+    }
+]
+```
+
+这一步的意义是把 PRD 里约定的 JSONB 结构提前固化到模型层，避免后续抓取、抽取、入库阶段对 `key_personnel` 的结构理解不一致。
+
+### 4. 建立了字段级 invariant
+
+当前已经为以下关键字段加入了强校验：
+
+- `id`
+  - 必须以 `COMP-` 开头
+  - 不能是空后缀
+
+- `credit_code`
+  - 统一转为去空格、全大写
+  - 必须是 18 位字母数字组合
+
+- `sources`
+  - 至少有一个来源
+  - 自动去重，同时保留原始顺序
+
+- `tech_tags` / `industry_tags` / `investors`
+  - 自动去重
+  - 自动去除空白项
+
+- `profile_embedding`
+  - 不能为空列表
+  - 只能包含有限浮点数，禁止 `NaN` / `inf`
+
+- `completeness_score`
+  - 必须在 `0-100` 范围内
+
+- `last_updated`
+  - 必须是带时区的时间
+
+这些 invariant 的核心目的不是“让模型更严格”本身，而是让后续阶段尽早失败：
+
+- 不合法的 `credit_code` 不应该进入去重逻辑
+- 无时区时间不应该进入最终持久化
+- 非法向量不应该等到数据库阶段才暴露
+
+---
+
+## 二、怎么使用
+
+### 1. 作为中间态记录使用
+
+当某条企业记录只有基础字段，还没有最终摘要和 embedding 时，应使用 `PartialCompanyRecord`：
+
+```python
+from company_data_agent.models.company_record import CompanySource, PartialCompanyRecord
+
+record = PartialCompanyRecord.model_validate(
+    {
+        "name": "深圳未来机器人有限公司",
+        "credit_code": "91440300MA5FUTURE1",
+        "sources": [CompanySource.MASTER_LIST],
+        "raw_data_path": "raw/company/91440300MA5FUTURE1/master.json",
+    }
+)
+```
+
+适合用于这些阶段：
+
+- 企业列表导入
+- 企名片返回结果合并后的临时态
+- 网页抓取字段抽取后的临时态
+
+### 2. 作为最终记录使用
+
+当记录已经满足入库和下游消费要求时，应使用 `FinalCompanyRecord`：
+
+```python
+from datetime import UTC, datetime
+
+from company_data_agent.models.company_record import CompanySource, FinalCompanyRecord
+
+record = FinalCompanyRecord.model_validate(
+    {
+        "id": "COMP-91440300MA5FUTURE1",
+        "name": "深圳未来机器人有限公司",
+        "credit_code": "91440300MA5FUTURE1",
+        "profile_summary": "一家聚焦手术机器人与智能控制系统的深圳科技企业，面向医院与科研机构提供核心机器人平台能力。",
+        "profile_embedding": [0.1, 0.2, 0.3],
+        "sources": [CompanySource.MASTER_LIST, CompanySource.WEBSITE],
+        "completeness_score": 78,
+        "last_updated": datetime(2026, 3, 21, 16, 0, tzinfo=UTC),
+        "raw_data_path": "raw/company/91440300MA5FUTURE1/final.json",
+    }
+)
+```
+
+适合用于这些阶段：
+
+- 最终质量校验后
+- PostgreSQL / JSONL 持久化前
+- 提供给下游 Phase 1 教授采集前
+
+### 3. 嵌套结构的使用方式
+
+`key_personnel` 允许直接传字典，Pydantic 会自动解析为强类型对象：
+
+```python
+record = PartialCompanyRecord.model_validate(
+    {
+        "name": "深圳未来机器人有限公司",
+        "credit_code": "91440300MA5FUTURE1",
+        "sources": [CompanySource.WEBSITE],
+        "raw_data_path": "raw/company/91440300MA5FUTURE1/website.json",
+        "key_personnel": [
+            {
+                "name": "张三",
+                "role": "CTO",
+                "education": [
+                    {
+                        "institution": "南方科技大学",
+                        "degree": "PhD",
+                        "year": 2020,
+                        "field": "机器人学",
+                    }
+                ],
+            }
+        ],
+    }
+)
+```
+
+这样后续代码可以直接访问：
+
+```python
+record.key_personnel[0].education[0].institution
+```
+
+而不必在业务逻辑层手工判断 JSON 结构是否完整。
+
+---
+
+## 三、怎么验证
+
+### 1. 自动化测试
+
+当前已经为 `Issue #9` 实现了 9 个测试，覆盖：
+
+- 最小合法中间态记录
+- 最终态记录的必填 invariant
+- 非法 `credit_code`
+- 非法 `id`
+- 越界 `completeness_score`
+- 无时区 `last_updated`
+- 非法 embedding 数值
+- 嵌套 `key_personnel` 结构
+- 空 `sources`
+
+在 `apps/company-data-agent` 目录下运行：
+
+```bash
+UV_CACHE_DIR=.uv-cache uv run pytest
+```
+
+当前验证结果：
+
+```text
+9 passed
+```
+
+### 2. 手工验证建议
+
+除了自动化测试，建议在交接或 code review 时手工确认以下几点：
+
+#### 验证点 A：中间态与最终态是否真正分离
+
+检查以下行为是否符合预期：
+
+- `PartialCompanyRecord` 允许缺少 `profile_summary`
+- `FinalCompanyRecord` 不允许缺少 `profile_summary`
+
+这可以防止后续实现把临时态误入库。
+
+#### 验证点 B：来源与标签字段是否去重且顺序稳定
+
+例如：
+
+```python
+sources=[CompanySource.MASTER_LIST, CompanySource.WEBSITE, CompanySource.MASTER_LIST]
+```
+
+应输出为：
+
+```python
+[CompanySource.MASTER_LIST, CompanySource.WEBSITE]
+```
+
+这保证后续合并逻辑是确定性的。
+
+#### 验证点 C：非法输入是否在模型层被拦截
+
+建议重点检查：
+
+- `credit_code="bad-code"`
+- `profile_embedding=[0.1, float("nan")]`
+- `last_updated=datetime(2026, 3, 21, 16, 0)`
+
+这些输入都应该在模型构造阶段失败，而不是延迟到更后面的阶段。
+
+---
+
+## 四、当前实现的边界
+
+这次完成的是“标准记录模型”和“字段 invariant”，还没有进入以下内容：
+
+- 配置 schema 与 artifact path contract
+- 企业列表导入
+- `credit_code` 到 `COMP-*` 的确定性 ID 生成算法
+- Qimingpian client
+- 网页抓取与字段抽取
+- `profile_summary` 生成
+- embedding provider 对接
+- completeness_score 计算
+- PostgreSQL / JSONL 持久化
+
+也就是说，这次完成的是后续所有任务都会依赖的“数据结构底座”，不是完整采集链路。
+
+---
+
+## 五、对后续任务的直接价值
+
+这次实现会直接降低后续任务的复杂度：
+
+- `#11/#12/#13`
+  可以直接把导入后的记录落到 `PartialCompanyRecord`
+
+- `#14/#15/#18`
+  可以围绕统一字段结构写 provider normalization 和 extraction 逻辑
+
+- `#19/#20/#21/#22`
+  可以明确依赖 `FinalCompanyRecord` 的最终字段约束，而不是重复写校验逻辑
+
+换句话说，后续 issue 不需要再争论“企业记录最终长什么样”，只需要在这个固定 contract 上继续补实现。

--- a/apps/company-data-agent/pyproject.toml
+++ b/apps/company-data-agent/pyproject.toml
@@ -1,0 +1,29 @@
+[project]
+name = "company-data-agent"
+version = "0.1.0"
+description = "Company data agent domain models and pipeline components"
+readme = "README.md"
+requires-python = ">=3.12"
+dependencies = [
+    "pydantic>=2.11.7",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/company_data_agent"]
+
+[dependency-groups]
+dev = [
+    "pytest>=8.4.1",
+]
+
+[tool.pytest.ini_options]
+minversion = "8.4"
+testpaths = ["tests"]
+addopts = [
+    "-rA",
+    "--show-capture=stderr",
+]

--- a/apps/company-data-agent/src/company_data_agent/__init__.py
+++ b/apps/company-data-agent/src/company_data_agent/__init__.py
@@ -1,0 +1,17 @@
+"""Company data agent package."""
+
+from company_data_agent.models.company_record import (
+    CompanySource,
+    EducationRecord,
+    FinalCompanyRecord,
+    KeyPersonnelRecord,
+    PartialCompanyRecord,
+)
+
+__all__ = [
+    "CompanySource",
+    "EducationRecord",
+    "FinalCompanyRecord",
+    "KeyPersonnelRecord",
+    "PartialCompanyRecord",
+]

--- a/apps/company-data-agent/src/company_data_agent/models/__init__.py
+++ b/apps/company-data-agent/src/company_data_agent/models/__init__.py
@@ -1,0 +1,17 @@
+"""Domain models for the company data agent."""
+
+from company_data_agent.models.company_record import (
+    CompanySource,
+    EducationRecord,
+    FinalCompanyRecord,
+    KeyPersonnelRecord,
+    PartialCompanyRecord,
+)
+
+__all__ = [
+    "CompanySource",
+    "EducationRecord",
+    "FinalCompanyRecord",
+    "KeyPersonnelRecord",
+    "PartialCompanyRecord",
+]

--- a/apps/company-data-agent/src/company_data_agent/models/company_record.py
+++ b/apps/company-data-agent/src/company_data_agent/models/company_record.py
@@ -1,0 +1,161 @@
+"""Canonical company record models used across the pipeline."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from enum import StrEnum
+from math import isfinite
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+
+class CompanySource(StrEnum):
+    """Known upstream sources for company data provenance."""
+
+    MASTER_LIST = "master_list"
+    QIMINGPIAN = "qimingpian"
+    WEBSITE = "website"
+    PR_NEWS = "pr_news"
+    WEB_SEARCH = "web_search"
+    MANUAL = "manual"
+
+
+class EducationRecord(BaseModel):
+    """Structured education record for a key person."""
+
+    model_config = ConfigDict(extra="forbid", str_strip_whitespace=True)
+
+    institution: str = Field(min_length=1)
+    degree: str | None = None
+    year: int | None = None
+    field: str | None = None
+
+
+class KeyPersonnelRecord(BaseModel):
+    """Structured representation of a key person mentioned by the company."""
+
+    model_config = ConfigDict(extra="forbid", str_strip_whitespace=True)
+
+    name: str = Field(min_length=1)
+    role: str = Field(min_length=1)
+    education: list[EducationRecord] = Field(default_factory=list)
+
+
+class CompanyRecordBase(BaseModel):
+    """Shared fields for partial and final company records."""
+
+    model_config = ConfigDict(
+        extra="forbid",
+        use_enum_values=True,
+        validate_assignment=True,
+        str_strip_whitespace=True,
+    )
+
+    id: str | None = None
+    name: str = Field(min_length=1)
+    credit_code: str = Field(min_length=18, max_length=18)
+    legal_representative: str | None = None
+    registered_capital: str | None = None
+    establishment_date: str | None = None
+    registered_address: str | None = None
+    industry: str | None = None
+    business_scope: str | None = None
+    product_description: str | None = None
+    tech_tags: list[str] = Field(default_factory=list)
+    industry_tags: list[str] = Field(default_factory=list)
+    financing_round: str | None = None
+    financing_amount: str | None = None
+    investors: list[str] = Field(default_factory=list)
+    patent_count: int | None = None
+    team_description: str | None = None
+    key_personnel: list[KeyPersonnelRecord] = Field(default_factory=list)
+    website: str | None = None
+    profile_summary: str | None = None
+    profile_embedding: list[float] | None = None
+    sources: list[CompanySource] = Field(default_factory=list, min_length=1)
+    completeness_score: int | None = None
+    last_updated: datetime | None = None
+    raw_data_path: str = Field(min_length=1)
+
+    @field_validator("id")
+    @classmethod
+    def validate_company_id(cls, value: str | None) -> str | None:
+        if value is None:
+            return value
+        if not value.startswith("COMP-") or len(value) <= len("COMP-"):
+            raise ValueError("company id must start with 'COMP-' and include a suffix")
+        return value
+
+    @field_validator("credit_code")
+    @classmethod
+    def validate_credit_code(cls, value: str) -> str:
+        normalized = value.strip().upper()
+        if len(normalized) != 18 or not normalized.isalnum():
+            raise ValueError("credit_code must be an 18-character alphanumeric string")
+        return normalized
+
+    @field_validator("sources")
+    @classmethod
+    def deduplicate_sources(cls, value: list[CompanySource]) -> list[CompanySource]:
+        deduped = list(dict.fromkeys(value))
+        if not deduped:
+            raise ValueError("sources must contain at least one source")
+        return deduped
+
+    @field_validator("tech_tags", "industry_tags", "investors")
+    @classmethod
+    def deduplicate_string_lists(cls, value: list[str]) -> list[str]:
+        items: list[str] = []
+        seen: set[str] = set()
+        for item in value:
+            normalized = item.strip()
+            if not normalized:
+                continue
+            if normalized not in seen:
+                seen.add(normalized)
+                items.append(normalized)
+        return items
+
+    @field_validator("profile_embedding")
+    @classmethod
+    def validate_profile_embedding(cls, value: list[float] | None) -> list[float] | None:
+        if value is None:
+            return value
+        if not value:
+            raise ValueError("profile_embedding must not be empty")
+        for component in value:
+            if not isfinite(component):
+                raise ValueError("profile_embedding must contain finite floats only")
+        return value
+
+    @field_validator("completeness_score")
+    @classmethod
+    def validate_completeness_score(cls, value: int | None) -> int | None:
+        if value is None:
+            return value
+        if value < 0 or value > 100:
+            raise ValueError("completeness_score must be between 0 and 100")
+        return value
+
+    @field_validator("last_updated")
+    @classmethod
+    def validate_last_updated(cls, value: datetime | None) -> datetime | None:
+        if value is None:
+            return value
+        if value.tzinfo is None or value.utcoffset() is None:
+            raise ValueError("last_updated must be timezone-aware")
+        return value
+
+
+class PartialCompanyRecord(CompanyRecordBase):
+    """Intermediate company record used before final retrieval fields exist."""
+
+
+class FinalCompanyRecord(CompanyRecordBase):
+    """Final record shape required before persistence and downstream handoff."""
+
+    id: str
+    profile_summary: str = Field(min_length=1)
+    profile_embedding: list[float] = Field(min_length=1)
+    completeness_score: int
+    last_updated: datetime

--- a/apps/company-data-agent/tests/test_company_record.py
+++ b/apps/company-data-agent/tests/test_company_record.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+from pydantic import ValidationError
+
+from company_data_agent.models.company_record import (
+    CompanySource,
+    FinalCompanyRecord,
+    PartialCompanyRecord,
+)
+
+
+def build_partial(**overrides: object) -> PartialCompanyRecord:
+    payload = {
+        "name": "深圳未来机器人有限公司",
+        "credit_code": "91440300MA5FUTURE1",
+        "sources": [CompanySource.MASTER_LIST],
+        "raw_data_path": "raw/company/91440300MA5FUTURE1/master.json",
+    }
+    payload.update(overrides)
+    return PartialCompanyRecord.model_validate(payload)
+
+
+def build_final(**overrides: object) -> FinalCompanyRecord:
+    payload = {
+        "id": "COMP-91440300MA5FUTURE1",
+        "name": "深圳未来机器人有限公司",
+        "credit_code": "91440300MA5FUTURE1",
+        "profile_summary": "一家聚焦手术机器人与智能控制系统的深圳科技企业，面向医院与科研机构提供核心机器人平台能力。",
+        "profile_embedding": [0.1, 0.2, 0.3],
+        "sources": [CompanySource.MASTER_LIST, CompanySource.WEBSITE],
+        "completeness_score": 78,
+        "last_updated": datetime(2026, 3, 21, 16, 0, tzinfo=UTC),
+        "raw_data_path": "raw/company/91440300MA5FUTURE1/final.json",
+    }
+    payload.update(overrides)
+    return FinalCompanyRecord.model_validate(payload)
+
+
+def test_partial_record_accepts_minimal_valid_payload() -> None:
+    record = build_partial()
+
+    assert record.id is None
+    assert record.credit_code == "91440300MA5FUTURE1"
+    assert record.sources == [CompanySource.MASTER_LIST]
+
+
+def test_final_record_requires_final_invariants() -> None:
+    record = build_final(sources=[CompanySource.MASTER_LIST, CompanySource.WEBSITE, CompanySource.MASTER_LIST])
+
+    assert record.id == "COMP-91440300MA5FUTURE1"
+    assert record.sources == [CompanySource.MASTER_LIST, CompanySource.WEBSITE]
+    assert record.profile_embedding == [0.1, 0.2, 0.3]
+
+
+def test_invalid_credit_code_is_rejected() -> None:
+    with pytest.raises(ValidationError, match="credit_code"):
+        build_partial(credit_code="bad-code")
+
+
+def test_invalid_company_id_is_rejected() -> None:
+    with pytest.raises(ValidationError, match="company id"):
+        build_final(id="BAD-91440300MA5FUTURE1")
+
+
+def test_completeness_score_must_stay_in_range() -> None:
+    with pytest.raises(ValidationError, match="completeness_score"):
+        build_final(completeness_score=101)
+
+
+def test_last_updated_must_be_timezone_aware() -> None:
+    with pytest.raises(ValidationError, match="timezone-aware"):
+        build_final(last_updated=datetime(2026, 3, 21, 16, 0))
+
+
+def test_embedding_must_contain_finite_numbers() -> None:
+    with pytest.raises(ValidationError, match="finite"):
+        build_final(profile_embedding=[0.1, float("nan")])
+
+
+def test_nested_key_personnel_payload_is_validated() -> None:
+    record = build_partial(
+        key_personnel=[
+            {
+                "name": "张三",
+                "role": "CTO",
+                "education": [
+                    {
+                        "institution": "南方科技大学",
+                        "degree": "PhD",
+                        "year": 2020,
+                        "field": "机器人学",
+                    }
+                ],
+            }
+        ]
+    )
+
+    assert record.key_personnel[0].education[0].institution == "南方科技大学"
+
+
+def test_sources_must_not_be_empty() -> None:
+    with pytest.raises(ValidationError, match="sources"):
+        build_partial(sources=[])

--- a/apps/company-data-agent/uv.lock
+++ b/apps/company-data-agent/uv.lock
@@ -1,0 +1,199 @@
+version = 1
+revision = 3
+requires-python = ">=3.12"
+
+[[package]]
+name = "annotated-types"
+version = "0.7.0"
+source = { registry = "https://mirrors.sustech.edu.cn/pypi/web/simple" }
+sdist = { url = "https://mirrors.sustech.edu.cn/pypi/web/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89" }
+wheels = [
+    { url = "https://mirrors.sustech.edu.cn/pypi/web/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://mirrors.sustech.edu.cn/pypi/web/simple" }
+sdist = { url = "https://mirrors.sustech.edu.cn/pypi/web/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44" }
+wheels = [
+    { url = "https://mirrors.sustech.edu.cn/pypi/web/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6" },
+]
+
+[[package]]
+name = "company-data-agent"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "pydantic" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "pydantic", specifier = ">=2.11.7" }]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pytest", specifier = ">=8.4.1" }]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://mirrors.sustech.edu.cn/pypi/web/simple" }
+sdist = { url = "https://mirrors.sustech.edu.cn/pypi/web/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730" }
+wheels = [
+    { url = "https://mirrors.sustech.edu.cn/pypi/web/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.0"
+source = { registry = "https://mirrors.sustech.edu.cn/pypi/web/simple" }
+sdist = { url = "https://mirrors.sustech.edu.cn/pypi/web/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4" }
+wheels = [
+    { url = "https://mirrors.sustech.edu.cn/pypi/web/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://mirrors.sustech.edu.cn/pypi/web/simple" }
+sdist = { url = "https://mirrors.sustech.edu.cn/pypi/web/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3" }
+wheels = [
+    { url = "https://mirrors.sustech.edu.cn/pypi/web/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746" },
+]
+
+[[package]]
+name = "pydantic"
+version = "2.12.5"
+source = { registry = "https://mirrors.sustech.edu.cn/pypi/web/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://mirrors.sustech.edu.cn/pypi/web/packages/69/44/36f1a6e523abc58ae5f928898e4aca2e0ea509b5aa6f6f392a5d882be928/pydantic-2.12.5.tar.gz", hash = "sha256:4d351024c75c0f085a9febbb665ce8c0c6ec5d30e903bdb6394b7ede26aebb49" }
+wheels = [
+    { url = "https://mirrors.sustech.edu.cn/pypi/web/packages/5a/87/b70ad306ebb6f9b585f114d0ac2137d792b48be34d732d60e597c2f8465a/pydantic-2.12.5-py3-none-any.whl", hash = "sha256:e561593fccf61e8a20fc46dfc2dfe075b8be7d0188df33f221ad1f0139180f9d" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.41.5"
+source = { registry = "https://mirrors.sustech.edu.cn/pypi/web/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://mirrors.sustech.edu.cn/pypi/web/packages/71/70/23b021c950c2addd24ec408e9ab05d59b035b39d97cdc1130e1bce647bb6/pydantic_core-2.41.5.tar.gz", hash = "sha256:08daa51ea16ad373ffd5e7606252cc32f07bc72b28284b6bc9c6df804816476e" }
+wheels = [
+    { url = "https://mirrors.sustech.edu.cn/pypi/web/packages/5f/5d/5f6c63eebb5afee93bcaae4ce9a898f3373ca23df3ccaef086d0233a35a7/pydantic_core-2.41.5-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:f41a7489d32336dbf2199c8c0a215390a751c5b014c2c1c5366e817202e9cdf7" },
+    { url = "https://mirrors.sustech.edu.cn/pypi/web/packages/aa/32/9c2e8ccb57c01111e0fd091f236c7b371c1bccea0fa85247ac55b1e2b6b6/pydantic_core-2.41.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:070259a8818988b9a84a449a2a7337c7f430a22acc0859c6b110aa7212a6d9c0" },
+    { url = "https://mirrors.sustech.edu.cn/pypi/web/packages/68/b8/a01b53cb0e59139fbc9e4fda3e9724ede8de279097179be4ff31f1abb65a/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e96cea19e34778f8d59fe40775a7a574d95816eb150850a85a7a4c8f4b94ac69" },
+    { url = "https://mirrors.sustech.edu.cn/pypi/web/packages/38/de/8c36b5198a29bdaade07b5985e80a233a5ac27137846f3bc2d3b40a47360/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ed2e99c456e3fadd05c991f8f437ef902e00eedf34320ba2b0842bd1c3ca3a75" },
+    { url = "https://mirrors.sustech.edu.cn/pypi/web/packages/00/b5/0e8e4b5b081eac6cb3dbb7e60a65907549a1ce035a724368c330112adfdd/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:65840751b72fbfd82c3c640cff9284545342a4f1eb1586ad0636955b261b0b05" },
+    { url = "https://mirrors.sustech.edu.cn/pypi/web/packages/77/56/87a61aad59c7c5b9dc8caad5a41a5545cba3810c3e828708b3d7404f6cef/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e536c98a7626a98feb2d3eaf75944ef6f3dbee447e1f841eae16f2f0a72d8ddc" },
+    { url = "https://mirrors.sustech.edu.cn/pypi/web/packages/0d/76/941cc9f73529988688a665a5c0ecff1112b3d95ab48f81db5f7606f522d3/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eceb81a8d74f9267ef4081e246ffd6d129da5d87e37a77c9bde550cb04870c1c" },
+    { url = "https://mirrors.sustech.edu.cn/pypi/web/packages/d3/43/ebef01f69baa07a482844faaa0a591bad1ef129253ffd0cdaa9d8a7f72d3/pydantic_core-2.41.5-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d38548150c39b74aeeb0ce8ee1d8e82696f4a4e16ddc6de7b1d8823f7de4b9b5" },
+    { url = "https://mirrors.sustech.edu.cn/pypi/web/packages/b1/87/41f3202e4193e3bacfc2c065fab7706ebe81af46a83d3e27605029c1f5a6/pydantic_core-2.41.5-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:c23e27686783f60290e36827f9c626e63154b82b116d7fe9adba1fda36da706c" },
+    { url = "https://mirrors.sustech.edu.cn/pypi/web/packages/49/7d/4c00df99cb12070b6bccdef4a195255e6020a550d572768d92cc54dba91a/pydantic_core-2.41.5-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:482c982f814460eabe1d3bb0adfdc583387bd4691ef00b90575ca0d2b6fe2294" },
+    { url = "https://mirrors.sustech.edu.cn/pypi/web/packages/cc/6a/ebf4b1d65d458f3cda6a7335d141305dfa19bdc61140a884d165a8a1bbc7/pydantic_core-2.41.5-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:bfea2a5f0b4d8d43adf9d7b8bf019fb46fdd10a2e5cde477fbcb9d1fa08c68e1" },
+    { url = "https://mirrors.sustech.edu.cn/pypi/web/packages/49/3b/774f2b5cd4192d5ab75870ce4381fd89cf218af999515baf07e7206753f0/pydantic_core-2.41.5-cp312-cp312-win32.whl", hash = "sha256:b74557b16e390ec12dca509bce9264c3bbd128f8a2c376eaa68003d7f327276d" },
+    { url = "https://mirrors.sustech.edu.cn/pypi/web/packages/86/45/00173a033c801cacf67c190fef088789394feaf88a98a7035b0e40d53dc9/pydantic_core-2.41.5-cp312-cp312-win_amd64.whl", hash = "sha256:1962293292865bca8e54702b08a4f26da73adc83dd1fcf26fbc875b35d81c815" },
+    { url = "https://mirrors.sustech.edu.cn/pypi/web/packages/f9/22/91fbc821fa6d261b376a3f73809f907cec5ca6025642c463d3488aad22fb/pydantic_core-2.41.5-cp312-cp312-win_arm64.whl", hash = "sha256:1746d4a3d9a794cacae06a5eaaccb4b8643a131d45fbc9af23e353dc0a5ba5c3" },
+    { url = "https://mirrors.sustech.edu.cn/pypi/web/packages/87/06/8806241ff1f70d9939f9af039c6c35f2360cf16e93c2ca76f184e76b1564/pydantic_core-2.41.5-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:941103c9be18ac8daf7b7adca8228f8ed6bb7a1849020f643b3a14d15b1924d9" },
+    { url = "https://mirrors.sustech.edu.cn/pypi/web/packages/94/02/abfa0e0bda67faa65fef1c84971c7e45928e108fe24333c81f3bfe35d5f5/pydantic_core-2.41.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:112e305c3314f40c93998e567879e887a3160bb8689ef3d2c04b6cc62c33ac34" },
+    { url = "https://mirrors.sustech.edu.cn/pypi/web/packages/15/df/a4c740c0943e93e6500f9eb23f4ca7ec9bf71b19e608ae5b579678c8d02f/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0cbaad15cb0c90aa221d43c00e77bb33c93e8d36e0bf74760cd00e732d10a6a0" },
+    { url = "https://mirrors.sustech.edu.cn/pypi/web/packages/9a/e3/6324802931ae1d123528988e0e86587c2072ac2e5394b4bc2bc34b61ff6e/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:03ca43e12fab6023fc79d28ca6b39b05f794ad08ec2feccc59a339b02f2b3d33" },
+    { url = "https://mirrors.sustech.edu.cn/pypi/web/packages/c9/d4/2230d7151d4957dd79c3044ea26346c148c98fbf0ee6ebd41056f2d62ab5/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:dc799088c08fa04e43144b164feb0c13f9a0bc40503f8df3e9fde58a3c0c101e" },
+    { url = "https://mirrors.sustech.edu.cn/pypi/web/packages/e6/9f/eaac5df17a3672fef0081b6c1bb0b82b33ee89aa5cec0d7b05f52fd4a1fa/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:97aeba56665b4c3235a0e52b2c2f5ae9cd071b8a8310ad27bddb3f7fb30e9aa2" },
+    { url = "https://mirrors.sustech.edu.cn/pypi/web/packages/cf/4e/35a80cae583a37cf15604b44240e45c05e04e86f9cfd766623149297e971/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:406bf18d345822d6c21366031003612b9c77b3e29ffdb0f612367352aab7d586" },
+    { url = "https://mirrors.sustech.edu.cn/pypi/web/packages/bf/e3/f6e262673c6140dd3305d144d032f7bd5f7497d3871c1428521f19f9efa2/pydantic_core-2.41.5-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:b93590ae81f7010dbe380cdeab6f515902ebcbefe0b9327cc4804d74e93ae69d" },
+    { url = "https://mirrors.sustech.edu.cn/pypi/web/packages/75/c7/20bd7fc05f0c6ea2056a4565c6f36f8968c0924f19b7d97bbfea55780e73/pydantic_core-2.41.5-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:01a3d0ab748ee531f4ea6c3e48ad9dac84ddba4b0d82291f87248f2f9de8d740" },
+    { url = "https://mirrors.sustech.edu.cn/pypi/web/packages/3a/8d/34318ef985c45196e004bc46c6eab2eda437e744c124ef0dbe1ff2c9d06b/pydantic_core-2.41.5-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:6561e94ba9dacc9c61bce40e2d6bdc3bfaa0259d3ff36ace3b1e6901936d2e3e" },
+    { url = "https://mirrors.sustech.edu.cn/pypi/web/packages/9c/59/013626bf8c78a5a5d9350d12e7697d3d4de951a75565496abd40ccd46bee/pydantic_core-2.41.5-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:915c3d10f81bec3a74fbd4faebe8391013ba61e5a1a8d48c4455b923bdda7858" },
+    { url = "https://mirrors.sustech.edu.cn/pypi/web/packages/1a/d9/c248c103856f807ef70c18a4f986693a46a8ffe1602e5d361485da502d20/pydantic_core-2.41.5-cp313-cp313-win32.whl", hash = "sha256:650ae77860b45cfa6e2cdafc42618ceafab3a2d9a3811fcfbd3bbf8ac3c40d36" },
+    { url = "https://mirrors.sustech.edu.cn/pypi/web/packages/9e/8b/341991b158ddab181cff136acd2552c9f35bd30380422a639c0671e99a91/pydantic_core-2.41.5-cp313-cp313-win_amd64.whl", hash = "sha256:79ec52ec461e99e13791ec6508c722742ad745571f234ea6255bed38c6480f11" },
+    { url = "https://mirrors.sustech.edu.cn/pypi/web/packages/73/7d/f2f9db34af103bea3e09735bb40b021788a5e834c81eedb541991badf8f5/pydantic_core-2.41.5-cp313-cp313-win_arm64.whl", hash = "sha256:3f84d5c1b4ab906093bdc1ff10484838aca54ef08de4afa9de0f5f14d69639cd" },
+    { url = "https://mirrors.sustech.edu.cn/pypi/web/packages/ea/28/46b7c5c9635ae96ea0fbb779e271a38129df2550f763937659ee6c5dbc65/pydantic_core-2.41.5-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:3f37a19d7ebcdd20b96485056ba9e8b304e27d9904d233d7b1015db320e51f0a" },
+    { url = "https://mirrors.sustech.edu.cn/pypi/web/packages/74/1a/145646e5687e8d9a1e8d09acb278c8535ebe9e972e1f162ed338a622f193/pydantic_core-2.41.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1d1d9764366c73f996edd17abb6d9d7649a7eb690006ab6adbda117717099b14" },
+    { url = "https://mirrors.sustech.edu.cn/pypi/web/packages/23/04/e89c29e267b8060b40dca97bfc64a19b2a3cf99018167ea1677d96368273/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:25e1c2af0fce638d5f1988b686f3b3ea8cd7de5f244ca147c777769e798a9cd1" },
+    { url = "https://mirrors.sustech.edu.cn/pypi/web/packages/84/a3/15a82ac7bd97992a82257f777b3583d3e84bdb06ba6858f745daa2ec8a85/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:506d766a8727beef16b7adaeb8ee6217c64fc813646b424d0804d67c16eddb66" },
+    { url = "https://mirrors.sustech.edu.cn/pypi/web/packages/74/9b/0046701313c6ef08c0c1cf0e028c67c770a4e1275ca73131563c5f2a310a/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4819fa52133c9aa3c387b3328f25c1facc356491e6135b459f1de698ff64d869" },
+    { url = "https://mirrors.sustech.edu.cn/pypi/web/packages/8a/cd/6bac76ecd1b27e75a95ca3a9a559c643b3afcd2dd62086d4b7a32a18b169/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2b761d210c9ea91feda40d25b4efe82a1707da2ef62901466a42492c028553a2" },
+    { url = "https://mirrors.sustech.edu.cn/pypi/web/packages/4c/d2/ef2074dc020dd6e109611a8be4449b98cd25e1b9b8a303c2f0fca2f2bcf7/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:22f0fb8c1c583a3b6f24df2470833b40207e907b90c928cc8d3594b76f874375" },
+    { url = "https://mirrors.sustech.edu.cn/pypi/web/packages/18/66/e9db17a9a763d72f03de903883c057b2592c09509ccfe468187f2a2eef29/pydantic_core-2.41.5-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2782c870e99878c634505236d81e5443092fba820f0373997ff75f90f68cd553" },
+    { url = "https://mirrors.sustech.edu.cn/pypi/web/packages/d3/9e/3ce66cebb929f3ced22be85d4c2399b8e85b622db77dad36b73c5387f8f8/pydantic_core-2.41.5-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:0177272f88ab8312479336e1d777f6b124537d47f2123f89cb37e0accea97f90" },
+    { url = "https://mirrors.sustech.edu.cn/pypi/web/packages/a6/62/205a998f4327d2079326b01abee48e502ea739d174f0a89295c481a2272e/pydantic_core-2.41.5-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:63510af5e38f8955b8ee5687740d6ebf7c2a0886d15a6d65c32814613681bc07" },
+    { url = "https://mirrors.sustech.edu.cn/pypi/web/packages/3c/0d/f05e79471e889d74d3d88f5bd20d0ed189ad94c2423d81ff8d0000aab4ff/pydantic_core-2.41.5-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:e56ba91f47764cc14f1daacd723e3e82d1a89d783f0f5afe9c364b8bb491ccdb" },
+    { url = "https://mirrors.sustech.edu.cn/pypi/web/packages/ec/e1/e08a6208bb100da7e0c4b288eed624a703f4d129bde2da475721a80cab32/pydantic_core-2.41.5-cp314-cp314-win32.whl", hash = "sha256:aec5cf2fd867b4ff45b9959f8b20ea3993fc93e63c7363fe6851424c8a7e7c23" },
+    { url = "https://mirrors.sustech.edu.cn/pypi/web/packages/48/5d/56ba7b24e9557f99c9237e29f5c09913c81eeb2f3217e40e922353668092/pydantic_core-2.41.5-cp314-cp314-win_amd64.whl", hash = "sha256:8e7c86f27c585ef37c35e56a96363ab8de4e549a95512445b85c96d3e2f7c1bf" },
+    { url = "https://mirrors.sustech.edu.cn/pypi/web/packages/4e/bb/f7a190991ec9e3e0ba22e4993d8755bbc4a32925c0b5b42775c03e8148f9/pydantic_core-2.41.5-cp314-cp314-win_arm64.whl", hash = "sha256:e672ba74fbc2dc8eea59fb6d4aed6845e6905fc2a8afe93175d94a83ba2a01a0" },
+    { url = "https://mirrors.sustech.edu.cn/pypi/web/packages/92/ed/77542d0c51538e32e15afe7899d79efce4b81eee631d99850edc2f5e9349/pydantic_core-2.41.5-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:8566def80554c3faa0e65ac30ab0932b9e3a5cd7f8323764303d468e5c37595a" },
+    { url = "https://mirrors.sustech.edu.cn/pypi/web/packages/bb/3d/6913dde84d5be21e284439676168b28d8bbba5600d838b9dca99de0fad71/pydantic_core-2.41.5-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:b80aa5095cd3109962a298ce14110ae16b8c1aece8b72f9dafe81cf597ad80b3" },
+    { url = "https://mirrors.sustech.edu.cn/pypi/web/packages/5a/f0/e5e6b99d4191da102f2b0eb9687aaa7f5bea5d9964071a84effc3e40f997/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3006c3dd9ba34b0c094c544c6006cc79e87d8612999f1a5d43b769b89181f23c" },
+    { url = "https://mirrors.sustech.edu.cn/pypi/web/packages/71/48/36fb760642d568925953bcc8116455513d6e34c4beaa37544118c36aba6d/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:72f6c8b11857a856bcfa48c86f5368439f74453563f951e473514579d44aa612" },
+    { url = "https://mirrors.sustech.edu.cn/pypi/web/packages/20/25/92dc684dd8eb75a234bc1c764b4210cf2646479d54b47bf46061657292a8/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5cb1b2f9742240e4bb26b652a5aeb840aa4b417c7748b6f8387927bc6e45e40d" },
+    { url = "https://mirrors.sustech.edu.cn/pypi/web/packages/e2/09/f53e0b05023d3e30357d82eb35835d0f6340ca344720a4599cd663dca599/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:bd3d54f38609ff308209bd43acea66061494157703364ae40c951f83ba99a1a9" },
+    { url = "https://mirrors.sustech.edu.cn/pypi/web/packages/aa/4e/2ae1aa85d6af35a39b236b1b1641de73f5a6ac4d5a7509f77b814885760c/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2ff4321e56e879ee8d2a879501c8e469414d948f4aba74a2d4593184eb326660" },
+    { url = "https://mirrors.sustech.edu.cn/pypi/web/packages/cd/13/2e215f17f0ef326fc72afe94776edb77525142c693767fc347ed6288728d/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d0d2568a8c11bf8225044aa94409e21da0cb09dcdafe9ecd10250b2baad531a9" },
+    { url = "https://mirrors.sustech.edu.cn/pypi/web/packages/02/7a/f999a6dcbcd0e5660bc348a3991c8915ce6599f4f2c6ac22f01d7a10816c/pydantic_core-2.41.5-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:a39455728aabd58ceabb03c90e12f71fd30fa69615760a075b9fec596456ccc3" },
+    { url = "https://mirrors.sustech.edu.cn/pypi/web/packages/3a/b1/6c990ac65e3b4c079a4fb9f5b05f5b013afa0f4ed6780a3dd236d2cbdc64/pydantic_core-2.41.5-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:239edca560d05757817c13dc17c50766136d21f7cd0fac50295499ae24f90fdf" },
+    { url = "https://mirrors.sustech.edu.cn/pypi/web/packages/d9/02/3c562f3a51afd4d88fff8dffb1771b30cfdfd79befd9883ee094f5b6c0d8/pydantic_core-2.41.5-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:2a5e06546e19f24c6a96a129142a75cee553cc018ffee48a460059b1185f4470" },
+    { url = "https://mirrors.sustech.edu.cn/pypi/web/packages/5c/96/5fb7d8c3c17bc8c62fdb031c47d77a1af698f1d7a406b0f79aaa1338f9ad/pydantic_core-2.41.5-cp314-cp314t-win32.whl", hash = "sha256:b4ececa40ac28afa90871c2cc2b9ffd2ff0bf749380fbdf57d165fd23da353aa" },
+    { url = "https://mirrors.sustech.edu.cn/pypi/web/packages/22/ed/182129d83032702912c2e2d8bbe33c036f342cc735737064668585dac28f/pydantic_core-2.41.5-cp314-cp314t-win_amd64.whl", hash = "sha256:80aa89cad80b32a912a65332f64a4450ed00966111b6615ca6816153d3585a8c" },
+    { url = "https://mirrors.sustech.edu.cn/pypi/web/packages/9f/ed/068e41660b832bb0b1aa5b58011dea2a3fe0ba7861ff38c4d4904c1c1a99/pydantic_core-2.41.5-cp314-cp314t-win_arm64.whl", hash = "sha256:35b44f37a3199f771c3eaa53051bc8a70cd7b54f333531c59e29fd4db5d15008" },
+    { url = "https://mirrors.sustech.edu.cn/pypi/web/packages/09/32/59b0c7e63e277fa7911c2fc70ccfb45ce4b98991e7ef37110663437005af/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:7da7087d756b19037bc2c06edc6c170eeef3c3bafcb8f532ff17d64dc427adfd" },
+    { url = "https://mirrors.sustech.edu.cn/pypi/web/packages/aa/81/05e400037eaf55ad400bcd318c05bb345b57e708887f07ddb2d20e3f0e98/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:aabf5777b5c8ca26f7824cb4a120a740c9588ed58df9b2d196ce92fba42ff8dc" },
+    { url = "https://mirrors.sustech.edu.cn/pypi/web/packages/6e/0d/e3549b2399f71d56476b77dbf3cf8937cec5cd70536bdc0e374a421d0599/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c007fe8a43d43b3969e8469004e9845944f1a80e6acd47c150856bb87f230c56" },
+    { url = "https://mirrors.sustech.edu.cn/pypi/web/packages/f7/07/34573da085946b6a313d7c42f82f16e8920bfd730665de2d11c0c37a74b5/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:76d0819de158cd855d1cbb8fcafdf6f5cf1eb8e470abe056d5d161106e38062b" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.19.2"
+source = { registry = "https://mirrors.sustech.edu.cn/pypi/web/simple" }
+sdist = { url = "https://mirrors.sustech.edu.cn/pypi/web/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887" }
+wheels = [
+    { url = "https://mirrors.sustech.edu.cn/pypi/web/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.2"
+source = { registry = "https://mirrors.sustech.edu.cn/pypi/web/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://mirrors.sustech.edu.cn/pypi/web/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11" }
+wheels = [
+    { url = "https://mirrors.sustech.edu.cn/pypi/web/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://mirrors.sustech.edu.cn/pypi/web/simple" }
+sdist = { url = "https://mirrors.sustech.edu.cn/pypi/web/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466" }
+wheels = [
+    { url = "https://mirrors.sustech.edu.cn/pypi/web/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.2"
+source = { registry = "https://mirrors.sustech.edu.cn/pypi/web/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://mirrors.sustech.edu.cn/pypi/web/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464" }
+wheels = [
+    { url = "https://mirrors.sustech.edu.cn/pypi/web/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7" },
+]


### PR DESCRIPTION
Closes #9

## Summary
- adds a new `apps/company-data-agent` package for the company pipeline domain model
- defines partial and final canonical company record schemas, source enums, and nested key-personnel models
- adds deterministic invariant tests for identity, provenance, timezone, score bounds, embeddings, and nested personnel payloads

## Audit Trail
- Chose Pydantic v2 models to make the company record contract explicit, runtime-validated, and easy to reuse across later import, enrichment, and persistence stages.
- Split the schema into `PartialCompanyRecord` and `FinalCompanyRecord` so earlier pipeline stages can hold incomplete enrichment state without weakening the final persistence contract.
- Canonicalized `sources` and repeated string-list fields with order-preserving deduplication to keep downstream merges deterministic.
- This issue is schema-only, so no x86_64 SIMD optimizations, Linux-specific syscalls, or memory-alignment strategies were implemented here.

## Verification
- `UV_CACHE_DIR=.uv-cache uv run pytest`
