### PR TITLE
feat: add company config contract for issue #10

### DIFF
--- a/apps/company-data-agent/README.md
+++ b/apps/company-data-agent/README.md
@@ -5,3 +5,4 @@
 ## 文档
 
 - [Issue 9 实现说明](docs/issue-9-公司记录模型说明.md)
+- [Issue 10 配置与路径约定说明](docs/issue-10-配置与路径约定说明.md)

--- a/apps/company-data-agent/docs/issue-10-配置与路径约定说明.md
+++ b/apps/company-data-agent/docs/issue-10-配置与路径约定说明.md
@@ -1,0 +1,338 @@
+# Issue 10 实现说明：配置模型与产物路径约定
+
+本文档说明 `Issue #10` 已完成的内容，包括：
+
+1. 实现了什么
+2. 如何使用
+3. 如何验证
+
+核心代码位于：
+
+- `src/company_data_agent/config/settings.py`
+- `tests/test_config_settings.py`
+
+---
+
+## 一、这次实现了什么
+
+`Issue #10` 的目标不是接入真实 provider，也不是开始导入企业数据，而是先把“配置 contract”和“产物路径 contract”固定下来，让后续 issue 都围绕同一套配置结构和路径规则工作。
+
+本次实现主要包含四部分。
+
+### 1. 建立了顶层配置模型 `CompanyDataAgentConfig`
+
+当前顶层配置分成这些部分：
+
+- `company_list_path`
+- `qimingpian`
+- `crawling`
+- `llm`
+- `embedding`
+- `postgres`
+- `artifacts`
+
+这意味着后续所有阶段都不需要再自行约定配置字段名，只需要消费这个统一结构。
+
+### 2. 建立了 provider 配置块
+
+实现了以下配置模型：
+
+- `QimingpianConfig`
+- `CrawlConfig`
+- `LLMConfig`
+- `EmbeddingConfig`
+- `PostgresConfig`
+
+这些模型做了两件事：
+
+- 保证字段存在且类型正确
+- 把明显错误的配置在启动前就拦截掉
+
+例如：
+
+- `cache_ttl_days` 必须大于 0
+- `rate_limit_per_minute` 必须大于 0
+- `dimensions` 必须大于 0
+- `delay_max_seconds` 不能小于 `delay_min_seconds`
+- `base_url` 必须是合法 URL
+
+这样后续执行阶段不会在跑到一半时才发现配置是坏的。
+
+### 3. 建立了环境变量引用对象 `EnvVarRef`
+
+为了满足“密钥来源于环境变量，而不是硬编码在配置里”的要求，这次没有直接把真实密钥放进配置模型，而是定义了：
+
+```python
+EnvVarRef(env_var="QIMINGPIAN_API_KEY")
+```
+
+这个对象负责两件事：
+
+- 校验环境变量名是否符合大写蛇形命名
+- 在真正运行前检查对应环境变量是否存在
+
+这样做的好处是：
+
+- 配置文件可以被安全提交，不包含敏感值
+- 缺失密钥时会在 provider 调用前失败，而不是运行到中途才报错
+
+### 4. 建立了产物路径解析器 `ArtifactLayout`
+
+这是本次最重要的 contract 之一。它统一定义了以下路径：
+
+- 标准化输出路径
+- 原始 payload 存储路径
+- Qimingpian 缓存路径
+- 爬取缓存路径
+- 运行报告路径
+
+当前约定包括：
+
+#### 标准输出
+
+```text
+artifacts/company-data-agent/runs/<run_id>/normalized/companies.jsonl
+```
+
+#### 原始数据
+
+```text
+artifacts/company-data-agent/raw/companies/<credit_code>/<source>/<filename>
+```
+
+#### Qimingpian 缓存
+
+```text
+artifacts/company-data-agent/cache/qimingpian/<credit_code>.json
+```
+
+#### Crawl 缓存
+
+```text
+artifacts/company-data-agent/cache/crawl/<hostname>/<filename>
+```
+
+#### 报告路径
+
+```text
+artifacts/company-data-agent/reports/<run_id>/<report_name>
+```
+
+同时，这些 helper 会拒绝简单的路径穿越风险，例如：
+
+- `../detail.json`
+- 带路径分隔符的非法文件名
+
+这样后续阶段不会在不同模块里手工拼路径，也不会出现同一个 artifact 被写到多个位置的情况。
+
+---
+
+## 二、怎么使用
+
+### 1. 解析配置
+
+可以直接从字典构造：
+
+```python
+from company_data_agent.config import CompanyDataAgentConfig
+
+config = CompanyDataAgentConfig.model_validate(
+    {
+        "company_list_path": "data/shenzhen_company_list.xlsx",
+        "qimingpian": {
+            "api_key": {"env_var": "QIMINGPIAN_API_KEY"},
+            "endpoint": "https://api.qimingpian.com",
+            "cache_ttl_days": 7,
+            "rate_limit_per_minute": 100,
+        },
+        "crawling": {
+            "max_concurrency": 3,
+            "delay_min_seconds": 2,
+            "delay_max_seconds": 5,
+            "timeout_seconds": 30,
+        },
+        "llm": {
+            "api_key": {"env_var": "SUMMARY_LLM_API_KEY"},
+            "base_url": "https://llm.internal.example/v1",
+            "model_name": "summary-model",
+        },
+        "embedding": {
+            "api_key": {"env_var": "EMBEDDING_API_KEY"},
+            "base_url": "https://embedding.internal.example/v1",
+            "model_name": "embedding-model",
+            "dimensions": 1024,
+        },
+        "postgres": {
+            "dsn": {"env_var": "POSTGRES_DSN"},
+            "schema": "public",
+            "companies_table": "companies",
+        },
+        "artifacts": {
+            "root_dir": "artifacts/company-data-agent",
+        },
+    }
+)
+```
+
+### 2. 在运行前检查环境变量
+
+```python
+config.validate_required_environment(os.environ)
+```
+
+如果某个必须的密钥不存在，会直接抛错。例如：
+
+- `QIMINGPIAN_API_KEY`
+- `SUMMARY_LLM_API_KEY`
+- `EMBEDDING_API_KEY`
+- `POSTGRES_DSN`
+
+这一步应该在任何 provider 调用之前执行。
+
+### 3. 解析固定路径
+
+可以通过 `ArtifactLayout` 生成后续阶段需要的路径：
+
+```python
+layout = config.artifacts
+
+normalized_path = layout.normalized_companies_path("full-2026-03")
+raw_path = layout.raw_payload_path(
+    "91440300MA5FUTURE1",
+    "qimingpian",
+    "detail.json",
+)
+cache_path = layout.qimingpian_cache_path("91440300MA5FUTURE1")
+report_path = layout.run_report_path("full-2026-03", "import-summary.json")
+```
+
+这意味着：
+
+- `#11/#13` 可以复用标准输出与报告路径
+- `#14/#15` 可以复用 Qimingpian cache path
+- `#16/#17/#18` 可以复用 raw/crawl cache path
+- `#23` 可以复用 run report path
+
+---
+
+## 三、怎么验证
+
+### 1. 自动化测试
+
+当前新增了 `test_config_settings.py`，覆盖：
+
+- 合法配置 fixture 是否能通过解析
+- 环境变量名是否符合要求
+- delay window 是否非法
+- 缺失密钥是否能在运行前失败
+- 路径解析是否稳定且确定
+- path traversal 是否被拒绝
+- URL 或 secret contract 非法时是否失败
+
+在 `apps/company-data-agent` 目录下执行：
+
+```bash
+UV_CACHE_DIR=.uv-cache uv run pytest
+```
+
+当前结果：
+
+```text
+16 passed
+```
+
+其中包含：
+
+- `Issue #9` 的 9 个模型测试
+- `Issue #10` 的 7 个配置/路径测试
+
+### 2. 手工验证建议
+
+建议 review 时重点看下面三类行为。
+
+#### 验证点 A：坏配置是否能在启动前失败
+
+比如：
+
+- `base_url = "not-a-url"`
+- `delay_min_seconds = 5, delay_max_seconds = 2`
+- `dimensions = 0`
+
+这些都应该在配置解析阶段失败。
+
+#### 验证点 B：密钥引用是否不依赖硬编码
+
+当前 contract 要求 API key 和 DSN 都通过 `EnvVarRef` 引用环境变量，而不是把真实值塞进配置。
+
+这意味着配置文件里应出现：
+
+```python
+{"env_var": "QIMINGPIAN_API_KEY"}
+```
+
+而不是：
+
+```python
+{"api_key": "real-secret"}
+```
+
+#### 验证点 C：路径是否稳定
+
+相同输入必须生成完全相同的路径，例如：
+
+```python
+layout.normalized_companies_path("full-2026-03")
+```
+
+应该稳定得到：
+
+```text
+artifacts/company-data-agent/runs/full-2026-03/normalized/companies.jsonl
+```
+
+这保证后续 pipeline 可以安全复跑，而不会把同类产物写到不同位置。
+
+---
+
+## 四、当前实现的边界
+
+这次完成的是 contract，不包含真实业务执行：
+
+- 不会读取 Excel/CSV
+- 不会发起 Qimingpian 请求
+- 不会抓网页
+- 不会生成 summary / embedding
+- 不会连接 PostgreSQL
+
+也就是说，这一层的职责只有两件事：
+
+1. 让配置先变成强约束对象
+2. 让产物路径先变成统一 contract
+
+后续 issue 才在这个基础上往上叠业务逻辑。
+
+---
+
+## 五、对后续任务的直接价值
+
+这次实现会直接服务于：
+
+- `#11`
+  使用 `company_list_path`
+
+- `#14/#15`
+  使用 `QimingpianConfig` 与 `qimingpian_cache_path`
+
+- `#16/#17/#18`
+  使用 `CrawlConfig` 与 crawl/raw path helper
+
+- `#19/#20`
+  使用 `LLMConfig` 和 `EmbeddingConfig`
+
+- `#22`
+  使用 `PostgresConfig`
+
+- `#23`
+  使用 `normalized_companies_path` 和 `run_report_path`
+
+因此，`Issue #10` 的价值不是“多写了一层配置对象”，而是把后续所有模块共享的启动参数和路径规则提前固定下来，避免后面继续分叉。

--- a/apps/company-data-agent/src/company_data_agent/__init__.py
+++ b/apps/company-data-agent/src/company_data_agent/__init__.py
@@ -1,5 +1,15 @@
 """Company data agent package."""
 
+from company_data_agent.config import (
+    ArtifactLayout,
+    CompanyDataAgentConfig,
+    CrawlConfig,
+    EmbeddingConfig,
+    EnvVarRef,
+    LLMConfig,
+    PostgresConfig,
+    QimingpianConfig,
+)
 from company_data_agent.models.company_record import (
     CompanySource,
     EducationRecord,
@@ -10,8 +20,16 @@ from company_data_agent.models.company_record import (
 
 __all__ = [
     "CompanySource",
+    "CompanyDataAgentConfig",
+    "CrawlConfig",
     "EducationRecord",
+    "EmbeddingConfig",
+    "EnvVarRef",
     "FinalCompanyRecord",
     "KeyPersonnelRecord",
+    "LLMConfig",
     "PartialCompanyRecord",
+    "PostgresConfig",
+    "QimingpianConfig",
+    "ArtifactLayout",
 ]

--- a/apps/company-data-agent/src/company_data_agent/config/__init__.py
+++ b/apps/company-data-agent/src/company_data_agent/config/__init__.py
@@ -1,0 +1,23 @@
+"""Configuration models and artifact path helpers for the company data agent."""
+
+from company_data_agent.config.settings import (
+    ArtifactLayout,
+    CompanyDataAgentConfig,
+    CrawlConfig,
+    EmbeddingConfig,
+    EnvVarRef,
+    LLMConfig,
+    PostgresConfig,
+    QimingpianConfig,
+)
+
+__all__ = [
+    "ArtifactLayout",
+    "CompanyDataAgentConfig",
+    "CrawlConfig",
+    "EmbeddingConfig",
+    "EnvVarRef",
+    "LLMConfig",
+    "PostgresConfig",
+    "QimingpianConfig",
+]

--- a/apps/company-data-agent/src/company_data_agent/config/settings.py
+++ b/apps/company-data-agent/src/company_data_agent/config/settings.py
@@ -1,0 +1,195 @@
+"""Strongly typed configuration models and artifact path helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from re import fullmatch
+from typing import Mapping
+
+from pydantic import AnyHttpUrl, BaseModel, ConfigDict, Field, field_validator
+
+
+def _validate_credit_code(credit_code: str) -> str:
+    normalized = credit_code.strip().upper()
+    if len(normalized) != 18 or not normalized.isalnum():
+        raise ValueError("credit_code must be an 18-character alphanumeric string")
+    return normalized
+
+
+def _validate_simple_filename(filename: str) -> str:
+    if not filename or filename in {".", ".."}:
+        raise ValueError("filename must not be empty")
+    if Path(filename).name != filename:
+        raise ValueError("filename must not contain path separators")
+    return filename
+
+
+def _validate_run_id(run_id: str) -> str:
+    normalized = run_id.strip()
+    if not normalized:
+        raise ValueError("run_id must not be empty")
+    if "/" in normalized or "\\" in normalized:
+        raise ValueError("run_id must not contain path separators")
+    return normalized
+
+
+class EnvVarRef(BaseModel):
+    """Reference to a required environment variable secret."""
+
+    model_config = ConfigDict(extra="forbid", str_strip_whitespace=True)
+
+    env_var: str = Field(min_length=1)
+
+    @field_validator("env_var")
+    @classmethod
+    def validate_env_var(cls, value: str) -> str:
+        normalized = value.strip()
+        if not fullmatch(r"[A-Z][A-Z0-9_]*", normalized):
+            raise ValueError(
+                "env_var must be uppercase snake case, for example QIMINGPIAN_API_KEY"
+            )
+        return normalized
+
+    def resolve(self, environ: Mapping[str, str]) -> str:
+        value = environ.get(self.env_var, "").strip()
+        if not value:
+            raise ValueError(
+                f"required environment variable '{self.env_var}' is not set or empty"
+            )
+        return value
+
+
+class QimingpianConfig(BaseModel):
+    """Configuration contract for the Qimingpian adapter."""
+
+    model_config = ConfigDict(extra="forbid", str_strip_whitespace=True)
+
+    api_key: EnvVarRef
+    endpoint: AnyHttpUrl
+    cache_ttl_days: int = Field(gt=0)
+    rate_limit_per_minute: int = Field(gt=0)
+
+
+class CrawlConfig(BaseModel):
+    """Configuration contract for website crawling."""
+
+    model_config = ConfigDict(extra="forbid", str_strip_whitespace=True)
+
+    max_concurrency: int = Field(gt=0)
+    delay_min_seconds: float = Field(ge=0)
+    delay_max_seconds: float = Field(ge=0)
+    timeout_seconds: int = Field(gt=0)
+
+    @field_validator("delay_max_seconds")
+    @classmethod
+    def validate_delay_window(cls, value: float, info) -> float:
+        delay_min = info.data.get("delay_min_seconds")
+        if delay_min is not None and value < delay_min:
+            raise ValueError("delay_max_seconds must be greater than or equal to delay_min_seconds")
+        return value
+
+
+class LLMConfig(BaseModel):
+    """Configuration contract for an LLM provider used by the pipeline."""
+
+    model_config = ConfigDict(extra="forbid", str_strip_whitespace=True)
+
+    api_key: EnvVarRef
+    base_url: AnyHttpUrl
+    model_name: str = Field(min_length=1)
+
+
+class EmbeddingConfig(BaseModel):
+    """Configuration contract for the embedding provider."""
+
+    model_config = ConfigDict(extra="forbid", str_strip_whitespace=True)
+
+    api_key: EnvVarRef
+    base_url: AnyHttpUrl
+    model_name: str = Field(min_length=1)
+    dimensions: int = Field(gt=0)
+
+
+class PostgresConfig(BaseModel):
+    """Configuration contract for PostgreSQL connectivity."""
+
+    model_config = ConfigDict(
+        extra="forbid",
+        str_strip_whitespace=True,
+        populate_by_name=True,
+    )
+
+    dsn: EnvVarRef
+    pg_schema: str = Field(min_length=1, alias="schema")
+    companies_table: str = Field(min_length=1, default="companies")
+
+
+class ArtifactLayout(BaseModel):
+    """Deterministic path resolver for normalized outputs, raw payloads, cache, and reports."""
+
+    model_config = ConfigDict(extra="forbid", str_strip_whitespace=True)
+
+    root_dir: Path
+
+    @field_validator("root_dir")
+    @classmethod
+    def validate_root_dir(cls, value: Path) -> Path:
+        if not str(value).strip():
+            raise ValueError("root_dir must not be empty")
+        return value
+
+    def normalized_companies_path(self, run_id: str) -> Path:
+        return self.root_dir / "runs" / _validate_run_id(run_id) / "normalized" / "companies.jsonl"
+
+    def raw_payload_path(self, credit_code: str, source: str, filename: str) -> Path:
+        normalized_source = _validate_simple_filename(source)
+        normalized_file = _validate_simple_filename(filename)
+        return (
+            self.root_dir
+            / "raw"
+            / "companies"
+            / _validate_credit_code(credit_code)
+            / normalized_source
+            / normalized_file
+        )
+
+    def qimingpian_cache_path(self, credit_code: str) -> Path:
+        return self.root_dir / "cache" / "qimingpian" / f"{_validate_credit_code(credit_code)}.json"
+
+    def crawl_cache_path(self, hostname: str, filename: str) -> Path:
+        normalized_host = _validate_simple_filename(hostname)
+        normalized_file = _validate_simple_filename(filename)
+        return self.root_dir / "cache" / "crawl" / normalized_host / normalized_file
+
+    def run_report_path(self, run_id: str, report_name: str) -> Path:
+        normalized_name = _validate_simple_filename(report_name)
+        return self.root_dir / "reports" / _validate_run_id(run_id) / normalized_name
+
+
+class CompanyDataAgentConfig(BaseModel):
+    """Top-level validated configuration for the company data agent."""
+
+    model_config = ConfigDict(extra="forbid", str_strip_whitespace=True)
+
+    company_list_path: Path
+    qimingpian: QimingpianConfig
+    crawling: CrawlConfig
+    llm: LLMConfig
+    embedding: EmbeddingConfig
+    postgres: PostgresConfig
+    artifacts: ArtifactLayout
+
+    @field_validator("company_list_path")
+    @classmethod
+    def validate_company_list_path(cls, value: Path) -> Path:
+        if not str(value).strip():
+            raise ValueError("company_list_path must not be empty")
+        return value
+
+    def validate_required_environment(self, environ: Mapping[str, str]) -> None:
+        """Fail fast if any referenced secret is missing."""
+
+        self.qimingpian.api_key.resolve(environ)
+        self.llm.api_key.resolve(environ)
+        self.embedding.api_key.resolve(environ)
+        self.postgres.dsn.resolve(environ)

--- a/apps/company-data-agent/tests/test_config_settings.py
+++ b/apps/company-data-agent/tests/test_config_settings.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from company_data_agent.config import ArtifactLayout, CompanyDataAgentConfig, EnvVarRef
+
+
+def build_config_payload() -> dict[str, object]:
+    return {
+        "company_list_path": "data/shenzhen_company_list.xlsx",
+        "qimingpian": {
+            "api_key": {"env_var": "QIMINGPIAN_API_KEY"},
+            "endpoint": "https://api.qimingpian.com",
+            "cache_ttl_days": 7,
+            "rate_limit_per_minute": 100,
+        },
+        "crawling": {
+            "max_concurrency": 3,
+            "delay_min_seconds": 2,
+            "delay_max_seconds": 5,
+            "timeout_seconds": 30,
+        },
+        "llm": {
+            "api_key": {"env_var": "SUMMARY_LLM_API_KEY"},
+            "base_url": "https://llm.internal.example/v1",
+            "model_name": "summary-model",
+        },
+        "embedding": {
+            "api_key": {"env_var": "EMBEDDING_API_KEY"},
+            "base_url": "https://embedding.internal.example/v1",
+            "model_name": "embedding-model",
+            "dimensions": 1024,
+        },
+        "postgres": {
+            "dsn": {"env_var": "POSTGRES_DSN"},
+            "schema": "public",
+            "companies_table": "companies",
+        },
+        "artifacts": {
+            "root_dir": "artifacts/company-data-agent",
+        },
+    }
+
+
+def test_config_parses_valid_fixture() -> None:
+    config = CompanyDataAgentConfig.model_validate(build_config_payload())
+
+    assert config.company_list_path == Path("data/shenzhen_company_list.xlsx")
+    assert config.qimingpian.rate_limit_per_minute == 100
+    assert config.crawling.delay_max_seconds == 5
+    assert config.embedding.dimensions == 1024
+
+
+def test_env_var_ref_requires_uppercase_snake_case() -> None:
+    with pytest.raises(ValidationError, match="uppercase snake case"):
+        EnvVarRef.model_validate({"env_var": "qimingpian_api_key"})
+
+
+def test_invalid_delay_window_is_rejected() -> None:
+    payload = build_config_payload()
+    payload["crawling"] = {
+        "max_concurrency": 3,
+        "delay_min_seconds": 5,
+        "delay_max_seconds": 2,
+        "timeout_seconds": 30,
+    }
+
+    with pytest.raises(ValidationError, match="delay_max_seconds"):
+        CompanyDataAgentConfig.model_validate(payload)
+
+
+def test_missing_required_environment_fails_fast() -> None:
+    config = CompanyDataAgentConfig.model_validate(build_config_payload())
+
+    with pytest.raises(ValueError, match="QIMINGPIAN_API_KEY"):
+        config.validate_required_environment(
+            {
+                "SUMMARY_LLM_API_KEY": "llm-key",
+                "EMBEDDING_API_KEY": "embed-key",
+                "POSTGRES_DSN": "postgresql://user:pass@localhost:5432/db",
+            }
+        )
+
+
+def test_artifact_layout_resolves_deterministic_paths() -> None:
+    layout = ArtifactLayout.model_validate({"root_dir": "artifacts/company-data-agent"})
+
+    assert layout.normalized_companies_path("full-2026-03") == Path(
+        "artifacts/company-data-agent/runs/full-2026-03/normalized/companies.jsonl"
+    )
+    assert layout.raw_payload_path(
+        "91440300MA5FUTURE1",
+        "qimingpian",
+        "detail.json",
+    ) == Path(
+        "artifacts/company-data-agent/raw/companies/91440300MA5FUTURE1/qimingpian/detail.json"
+    )
+    assert layout.qimingpian_cache_path("91440300MA5FUTURE1") == Path(
+        "artifacts/company-data-agent/cache/qimingpian/91440300MA5FUTURE1.json"
+    )
+    assert layout.crawl_cache_path("future-robotics.com", "homepage.html") == Path(
+        "artifacts/company-data-agent/cache/crawl/future-robotics.com/homepage.html"
+    )
+    assert layout.run_report_path("full-2026-03", "import-summary.json") == Path(
+        "artifacts/company-data-agent/reports/full-2026-03/import-summary.json"
+    )
+
+
+def test_artifact_layout_rejects_path_traversal_segments() -> None:
+    layout = ArtifactLayout.model_validate({"root_dir": "artifacts/company-data-agent"})
+
+    with pytest.raises(ValueError, match="path separators"):
+        layout.raw_payload_path("91440300MA5FUTURE1", "qimingpian", "../detail.json")
+
+
+def test_invalid_url_or_secret_contract_is_rejected() -> None:
+    payload = build_config_payload()
+    payload["embedding"] = {
+        "api_key": {"env_var": "EMBEDDING_API_KEY"},
+        "base_url": "not-a-url",
+        "model_name": "embedding-model",
+        "dimensions": 1024,
+    }
+
+    with pytest.raises(ValidationError, match="URL"):
+        CompanyDataAgentConfig.model_validate(payload)


### PR DESCRIPTION
Closes #10

## Summary
- adds strongly typed configuration models for company list import, Qimingpian, crawling, LLM, embedding, PostgreSQL, and artifact layout
- adds deterministic artifact path helpers for normalized outputs, raw payloads, provider caches, and run reports
- adds validation for malformed config, missing environment-backed secrets, invalid delay windows, and unsafe path segments
- includes a Chinese usage and verification document for the configuration contract

## Audit Trail
- Chose explicit Pydantic v2 config models so later pipeline stages can fail fast on invalid configuration before any provider or storage side effect happens.
- Introduced `EnvVarRef` instead of embedding secrets directly into config payloads, keeping the contract safe to commit while still making missing secrets a startup error.
- Centralized artifact path construction in `ArtifactLayout` so downstream importer, crawler, cache, and reporting code reuse one deterministic directory contract.
- This issue is configuration-contract work only, so no x86_64 SIMD optimizations, Linux-specific syscalls, or memory-alignment strategies were implemented here.

## Verification
- `UV_CACHE_DIR=.uv-cache uv run pytest`
