### PR TITLE
feat: add company master-list parser for issue #11

### DIFF
--- a/apps/company-data-agent/README.md
+++ b/apps/company-data-agent/README.md
@@ -6,3 +6,4 @@
 
 - [Issue 9 实现说明](docs/issue-9-公司记录模型说明.md)
 - [Issue 10 配置与路径约定说明](docs/issue-10-配置与路径约定说明.md)
+- [Issue 11 主数据表解析说明](docs/issue-11-主数据表解析说明.md)

--- a/apps/company-data-agent/docs/issue-11-主数据表解析说明.md
+++ b/apps/company-data-agent/docs/issue-11-主数据表解析说明.md
@@ -1,0 +1,308 @@
+# Issue 11 实现说明：深圳企业主数据表解析
+
+本文档说明 `Issue #11` 的真实实现内容，包括：
+
+1. 实现了什么
+2. 如何使用
+3. 如何验证
+
+核心代码位于：
+
+- `src/company_data_agent/ingest/master_list_parser.py`
+- `tests/test_master_list_parser.py`
+
+---
+
+## 一、这次实现了什么
+
+这次实现的是企业数据采集链路中的第一块真实业务能力：
+
+**把深圳企业主数据表的 CSV / Excel 输入解析成可复用的标准化行流。**
+
+这不是文档层面的约定，而是已经可以直接调用的 parser。
+
+### 1. 支持 CSV 和 Excel 两种输入
+
+当前 `MasterListParser` 支持：
+
+- `.csv`
+- `.xlsx`
+- `.xlsm`
+
+这意味着后续不管企业主表来自 CSV 还是 Excel，解析入口都一致。
+
+### 2. 产出标准化行对象，而不是原始二维表
+
+解析结果不是裸 `dict` 列表，而是结构化输出：
+
+- `ParsedMasterListRow`
+- `MasterListParseError`
+- `MasterListParseResult`
+
+其中：
+
+- `rows` 保存成功解析的行
+- `errors` 保存逐行失败信息
+
+这样后续 `#12/#13` 可以直接消费 `rows` 做规范化、去重和导入报告，而不需要重新读文件。
+
+### 3. 做了 header alias 映射
+
+当前 parser 已支持把常见中英文表头映射成统一字段：
+
+- `企业名称` / `公司名称` / `name` / `company_name` -> `name`
+- `统一社会信用代码` / `信用代码` / `credit_code` -> `credit_code`
+- `注册地址` / `地址` / `registered_address` -> `registered_address`
+- `行业分类` / `行业` / `industry` -> `industry`
+
+这一步很关键，因为实际输入文件的列名不一定完全统一。如果不先做 alias 归一，后续导入阶段会被各种列名分叉拖垮。
+
+### 4. 逐行失败，不中断整批成功数据
+
+当前 parser 对坏行的处理方式是：
+
+- 记录为 `MasterListParseError`
+- 保留原始列内容
+- 继续解析剩余有效行
+
+这满足了 issue 的核心要求：
+
+> malformed-row fixtures generate structured parse errors while valid rows still load
+
+也就是说，一行坏数据不会导致整批主数据表无法读取。
+
+### 5. 支持空白行跳过与额外列保留
+
+当前已经实现：
+
+- 全空白行自动跳过
+- 非关键列不会丢失，会进入 `extra_columns`
+
+例如像 `企业状态`、`notes` 这类当前未正式入库、但后面可能用于排查和补充的信息，会被保留下来，而不是在解析阶段直接丢弃。
+
+---
+
+## 二、输出结构说明
+
+### 1. 成功行 `ParsedMasterListRow`
+
+每一行成功解析后，当前至少包含这些字段：
+
+- `row_number`
+- `source_path`
+- `raw_columns`
+- `name`
+- `credit_code`
+- `registered_address`
+- `industry`
+- `extra_columns`
+
+这里的设计意图是：
+
+- `raw_columns` 用于回溯原始行数据
+- 关键字段先抽出来，供后续标准化和导入逻辑使用
+- 其他未映射字段进入 `extra_columns`，避免信息损失
+
+### 2. 错误行 `MasterListParseError`
+
+错误对象当前包含：
+
+- `row_number`
+- `source_path`
+- `message`
+- `raw_columns`
+
+这样后续生成导入报告时可以准确回答：
+
+- 哪一行失败
+- 为什么失败
+- 原始内容是什么
+
+---
+
+## 三、怎么使用
+
+### 1. 直接解析 CSV
+
+```python
+from company_data_agent.ingest import MasterListParser
+
+parser = MasterListParser()
+result = parser.parse("data/shenzhen_company_list.csv")
+
+print(len(result.rows))
+print(len(result.errors))
+```
+
+### 2. 直接解析 Excel
+
+```python
+from company_data_agent.ingest import MasterListParser
+
+parser = MasterListParser()
+result = parser.parse("data/shenzhen_company_list.xlsx")
+
+for row in result.rows:
+    print(row.name, row.credit_code)
+```
+
+### 3. 使用成功行
+
+```python
+for row in result.rows:
+    print(
+        row.row_number,
+        row.name,
+        row.credit_code,
+        row.registered_address,
+        row.industry,
+    )
+```
+
+### 4. 使用错误行
+
+```python
+for error in result.errors:
+    print(error.row_number, error.message, error.raw_columns)
+```
+
+这就是后续 `#13` 生成“失败 N 条”的导入报告的直接输入。
+
+---
+
+## 四、当前支持的解析行为
+
+### 1. 空白行跳过
+
+如果整行都是空值，parser 会直接跳过，不计入成功，也不计入错误。
+
+### 2. 必要字段缺失时报错
+
+当前必要字段是：
+
+- `name`
+- `credit_code`
+
+只要这两个字段中有任意一个为空，该行会进入 `errors`，不会进入 `rows`。
+
+### 3. 额外列保留
+
+例如输入中有：
+
+- `企业状态`
+- `notes`
+- `备注`
+
+这类当前没有映射为 canonical 字段的列，会保留在：
+
+```python
+row.extra_columns
+```
+
+### 4. 不支持的文件格式立即失败
+
+比如：
+
+- `.json`
+- `.txt`
+
+这类输入不会尝试“猜测解析”，而是立即报：
+
+```text
+unsupported master list format
+```
+
+这样可以避免错误输入被悄悄接受。
+
+---
+
+## 五、怎么验证
+
+### 1. 自动化测试
+
+当前 `Issue #11` 新增了 5 个 parser 测试，覆盖：
+
+- CSV 正常解析
+- Excel 正常解析
+- 空白行跳过
+- 单行错误不影响其他成功行
+- 标准化输出快照一致
+- 不支持格式报错
+
+在 `apps/company-data-agent` 目录运行：
+
+```bash
+UV_CACHE_DIR=.uv-cache uv run pytest
+```
+
+当前结果：
+
+```text
+21 passed
+```
+
+其中包括：
+
+- `#9` 的模型测试
+- `#10` 的配置 contract 测试
+- `#11` 的主数据表解析测试
+
+### 2. 手工验证建议
+
+建议重点看这几个点。
+
+#### 验证点 A：不同 header 别名是否归一
+
+例如：
+
+- `企业名称`
+- `公司名称`
+- `name`
+
+都应该最终映射到同一个 canonical 字段 `name`。
+
+#### 验证点 B：坏行是否只影响自己
+
+例如某行 `企业名称` 为空时：
+
+- 这行应该进入 `errors`
+- 其他合法行仍然进入 `rows`
+
+#### 验证点 C：额外列是否保留
+
+如果源文件里有暂时未映射字段，不应该丢失，而应该进入 `extra_columns`。
+
+---
+
+## 六、当前实现边界
+
+这次实现只到“解析主数据表”为止，还没有进入：
+
+- `credit_code` 规范化与企业 ID 生成
+- 去重策略
+- 导入报告汇总
+- Qimingpian 增强
+- 网页抓取
+- 持久化
+
+换句话说：
+
+- `#11` 解决的是“把文件稳定读进来”
+- `#12` 解决的是“把 identity 规范起来”
+- `#13` 解决的是“把解析后的行变成 skeleton 记录并出报告”
+
+这三张是按 docs 里的采集流程顺序往下落的，不是文档空转。
+
+---
+
+## 七、对后续任务的直接价值
+
+`Issue #11` 完成后，后续任务已经有明确输入：
+
+- `#12`
+  直接消费 `ParsedMasterListRow.name` 和 `credit_code`
+
+- `#13`
+  直接消费 `rows` 和 `errors` 来做 skeleton import 与导入报告
+
+因此从这一步开始，企业数据采集已经不是“只有 contract”，而是有了真正的可执行入口。

--- a/apps/company-data-agent/pyproject.toml
+++ b/apps/company-data-agent/pyproject.toml
@@ -5,6 +5,7 @@ description = "Company data agent domain models and pipeline components"
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
+    "openpyxl>=3.1.5",
     "pydantic>=2.11.7",
 ]
 

--- a/apps/company-data-agent/src/company_data_agent/__init__.py
+++ b/apps/company-data-agent/src/company_data_agent/__init__.py
@@ -10,6 +10,12 @@ from company_data_agent.config import (
     PostgresConfig,
     QimingpianConfig,
 )
+from company_data_agent.ingest import (
+    MasterListParseError,
+    MasterListParseResult,
+    MasterListParser,
+    ParsedMasterListRow,
+)
 from company_data_agent.models.company_record import (
     CompanySource,
     EducationRecord,
@@ -26,9 +32,13 @@ __all__ = [
     "EmbeddingConfig",
     "EnvVarRef",
     "FinalCompanyRecord",
+    "MasterListParseError",
+    "MasterListParseResult",
+    "MasterListParser",
     "KeyPersonnelRecord",
     "LLMConfig",
     "PartialCompanyRecord",
+    "ParsedMasterListRow",
     "PostgresConfig",
     "QimingpianConfig",
     "ArtifactLayout",

--- a/apps/company-data-agent/src/company_data_agent/ingest/__init__.py
+++ b/apps/company-data-agent/src/company_data_agent/ingest/__init__.py
@@ -1,0 +1,15 @@
+"""Input parsing for company master list sources."""
+
+from company_data_agent.ingest.master_list_parser import (
+    MasterListParseError,
+    MasterListParseResult,
+    MasterListParser,
+    ParsedMasterListRow,
+)
+
+__all__ = [
+    "MasterListParseError",
+    "MasterListParseResult",
+    "MasterListParser",
+    "ParsedMasterListRow",
+]

--- a/apps/company-data-agent/src/company_data_agent/ingest/master_list_parser.py
+++ b/apps/company-data-agent/src/company_data_agent/ingest/master_list_parser.py
@@ -1,0 +1,215 @@
+"""Parser for Shenzhen company master-list inputs in CSV and Excel formats."""
+
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+from typing import Any
+
+from openpyxl import load_workbook
+from pydantic import BaseModel, ConfigDict, Field
+
+
+HEADER_ALIASES: dict[str, str] = {
+    "企业名称": "name",
+    "公司名称": "name",
+    "name": "name",
+    "company_name": "name",
+    "统一社会信用代码": "credit_code",
+    "信用代码": "credit_code",
+    "credit_code": "credit_code",
+    "unified_social_credit_code": "credit_code",
+    "注册地址": "registered_address",
+    "地址": "registered_address",
+    "registered_address": "registered_address",
+    "行业分类": "industry",
+    "行业": "industry",
+    "industry": "industry",
+}
+
+REQUIRED_CANONICAL_HEADERS = {"name", "credit_code"}
+
+
+class ParsedMasterListRow(BaseModel):
+    """Normalized row produced by the master-list parser."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    row_number: int
+    source_path: str
+    raw_columns: dict[str, str | None]
+    name: str
+    credit_code: str
+    registered_address: str | None = None
+    industry: str | None = None
+    extra_columns: dict[str, str | None] = Field(default_factory=dict)
+
+
+class MasterListParseError(BaseModel):
+    """Structured parse error for a single source row."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    row_number: int
+    source_path: str
+    message: str
+    raw_columns: dict[str, str | None]
+
+
+class MasterListParseResult(BaseModel):
+    """Rows and row-level failures emitted by the parser."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    rows: list[ParsedMasterListRow]
+    errors: list[MasterListParseError]
+    source_path: str
+
+
+class MasterListParser:
+    """Parse CSV or Excel company master-list files into normalized rows."""
+
+    def parse(self, source_path: str | Path) -> MasterListParseResult:
+        path = Path(source_path)
+        suffix = path.suffix.lower()
+        if suffix == ".csv":
+            raw_rows = self._read_csv(path)
+        elif suffix in {".xlsx", ".xlsm"}:
+            raw_rows = self._read_xlsx(path)
+        else:
+            raise ValueError(f"unsupported master list format: {path.suffix}")
+
+        return self._normalize_rows(path, raw_rows)
+
+    def _read_csv(self, path: Path) -> list[tuple[int, dict[str, str | None]]]:
+        with path.open("r", encoding="utf-8-sig", newline="") as handle:
+            reader = csv.DictReader(handle)
+            if reader.fieldnames is None:
+                raise ValueError("csv input must include a header row")
+            return [
+                (index, self._normalize_raw_columns(row))
+                for index, row in enumerate(reader, start=2)
+            ]
+
+    def _read_xlsx(self, path: Path) -> list[tuple[int, dict[str, str | None]]]:
+        workbook = load_workbook(path, read_only=True, data_only=True)
+        sheet = workbook.active
+        header_cells = next(sheet.iter_rows(min_row=1, max_row=1, values_only=True), None)
+        if header_cells is None:
+            raise ValueError("excel input must include a header row")
+        headers = [self._stringify_header(value) for value in header_cells]
+        if not any(headers):
+            raise ValueError("excel header row must not be empty")
+
+        rows: list[tuple[int, dict[str, str | None]]] = []
+        for index, values in enumerate(
+            sheet.iter_rows(min_row=2, values_only=True),
+            start=2,
+        ):
+            row: dict[str, str | None] = {}
+            for header, value in zip(headers, values, strict=False):
+                if header is None:
+                    continue
+                row[header] = self._stringify_cell(value)
+            rows.append((index, self._normalize_raw_columns(row)))
+        workbook.close()
+        return rows
+
+    def _normalize_rows(
+        self,
+        path: Path,
+        raw_rows: list[tuple[int, dict[str, str | None]]],
+    ) -> MasterListParseResult:
+        rows: list[ParsedMasterListRow] = []
+        errors: list[MasterListParseError] = []
+
+        for row_number, raw_columns in raw_rows:
+            if self._is_blank_row(raw_columns):
+                continue
+
+            canonical_columns = self._map_to_canonical_columns(raw_columns)
+            missing = [
+                column
+                for column in sorted(REQUIRED_CANONICAL_HEADERS)
+                if not canonical_columns.get(column)
+            ]
+            if missing:
+                errors.append(
+                    MasterListParseError(
+                        row_number=row_number,
+                        source_path=str(path),
+                        message=f"missing required columns: {', '.join(missing)}",
+                        raw_columns=raw_columns,
+                    )
+                )
+                continue
+
+            rows.append(
+                ParsedMasterListRow(
+                    row_number=row_number,
+                    source_path=str(path),
+                    raw_columns=raw_columns,
+                    name=canonical_columns["name"],
+                    credit_code=canonical_columns["credit_code"],
+                    registered_address=canonical_columns.get("registered_address"),
+                    industry=canonical_columns.get("industry"),
+                    extra_columns=self._extract_extra_columns(raw_columns),
+                )
+            )
+
+        return MasterListParseResult(rows=rows, errors=errors, source_path=str(path))
+
+    def _map_to_canonical_columns(
+        self,
+        raw_columns: dict[str, str | None],
+    ) -> dict[str, str | None]:
+        canonical: dict[str, str | None] = {}
+        for raw_header, value in raw_columns.items():
+            alias_key = raw_header.strip().lower()
+            canonical_name = HEADER_ALIASES.get(raw_header) or HEADER_ALIASES.get(alias_key)
+            if canonical_name is None:
+                continue
+            if canonical_name not in canonical or not canonical[canonical_name]:
+                canonical[canonical_name] = value
+        return canonical
+
+    def _extract_extra_columns(
+        self,
+        raw_columns: dict[str, str | None],
+    ) -> dict[str, str | None]:
+        extra: dict[str, str | None] = {}
+        for raw_header, value in raw_columns.items():
+            alias_key = raw_header.strip().lower()
+            canonical_name = HEADER_ALIASES.get(raw_header) or HEADER_ALIASES.get(alias_key)
+            if canonical_name is None:
+                extra[raw_header] = value
+        return extra
+
+    def _normalize_raw_columns(
+        self,
+        row: dict[str, Any],
+    ) -> dict[str, str | None]:
+        normalized: dict[str, str | None] = {}
+        for key, value in row.items():
+            if key is None:
+                continue
+            header = str(key).strip()
+            if not header:
+                continue
+            normalized[header] = self._stringify_cell(value)
+        return normalized
+
+    def _is_blank_row(self, row: dict[str, str | None]) -> bool:
+        return not any(value for value in row.values())
+
+    def _stringify_header(self, value: Any) -> str | None:
+        if value is None:
+            return None
+        text = str(value).strip()
+        return text or None
+
+    def _stringify_cell(self, value: Any) -> str | None:
+        if value is None:
+            return None
+        text = str(value).strip()
+        return text or None

--- a/apps/company-data-agent/tests/test_master_list_parser.py
+++ b/apps/company-data-agent/tests/test_master_list_parser.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+
+from openpyxl import Workbook
+
+from company_data_agent.ingest import MasterListParser
+
+
+def write_csv(path: Path, rows: list[dict[str, str]]) -> None:
+    with path.open("w", encoding="utf-8-sig", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=list(rows[0].keys()))
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def write_xlsx(path: Path, headers: list[str], rows: list[list[str | None]]) -> None:
+    workbook = Workbook()
+    sheet = workbook.active
+    sheet.append(headers)
+    for row in rows:
+        sheet.append(row)
+    workbook.save(path)
+
+
+def test_parser_accepts_csv_and_preserves_extra_columns(tmp_path: Path) -> None:
+    source = tmp_path / "companies.csv"
+    write_csv(
+        source,
+        [
+            {
+                "企业名称": "深圳未来机器人有限公司",
+                "统一社会信用代码": "91440300MA5FUTURE1",
+                "注册地址": "深圳市南山区",
+                "行业分类": "机器人",
+                "企业状态": "存续",
+            },
+            {
+                "企业名称": "深圳智算科技有限公司",
+                "统一社会信用代码": "91440300MA5INTELAI",
+                "注册地址": "深圳市福田区",
+                "行业分类": "人工智能",
+                "企业状态": "存续",
+            },
+        ],
+    )
+
+    result = MasterListParser().parse(source)
+
+    assert len(result.rows) == 2
+    assert not result.errors
+    assert result.rows[0].name == "深圳未来机器人有限公司"
+    assert result.rows[0].credit_code == "91440300MA5FUTURE1"
+    assert result.rows[0].registered_address == "深圳市南山区"
+    assert result.rows[0].industry == "机器人"
+    assert result.rows[0].extra_columns == {"企业状态": "存续"}
+
+
+def test_parser_accepts_xlsx_and_skips_blank_rows(tmp_path: Path) -> None:
+    source = tmp_path / "companies.xlsx"
+    write_xlsx(
+        source,
+        ["公司名称", "信用代码", "地址", "行业"],
+        [
+            ["深圳未来机器人有限公司", "91440300MA5FUTURE1", "深圳市南山区", "机器人"],
+            [None, None, None, None],
+            ["深圳智算科技有限公司", "91440300MA5INTELAI", "深圳市福田区", "人工智能"],
+        ],
+    )
+
+    result = MasterListParser().parse(source)
+
+    assert len(result.rows) == 2
+    assert result.rows[0].row_number == 2
+    assert result.rows[1].row_number == 4
+    assert not result.errors
+
+
+def test_parser_surfaces_row_level_errors_without_aborting_valid_rows(tmp_path: Path) -> None:
+    source = tmp_path / "companies.csv"
+    write_csv(
+        source,
+        [
+            {
+                "企业名称": "深圳未来机器人有限公司",
+                "统一社会信用代码": "91440300MA5FUTURE1",
+                "注册地址": "深圳市南山区",
+                "行业分类": "机器人",
+            },
+            {
+                "企业名称": "",
+                "统一社会信用代码": "91440300MA5BROKEN01",
+                "注册地址": "深圳市宝安区",
+                "行业分类": "制造业",
+            },
+            {
+                "企业名称": "深圳智算科技有限公司",
+                "统一社会信用代码": "91440300MA5INTELAI",
+                "注册地址": "深圳市福田区",
+                "行业分类": "人工智能",
+            },
+        ],
+    )
+
+    result = MasterListParser().parse(source)
+
+    assert [row.name for row in result.rows] == [
+        "深圳未来机器人有限公司",
+        "深圳智算科技有限公司",
+    ]
+    assert len(result.errors) == 1
+    assert result.errors[0].row_number == 3
+    assert "missing required columns: name" == result.errors[0].message
+
+
+def test_parser_produces_stable_normalized_snapshot(tmp_path: Path) -> None:
+    source = tmp_path / "companies.csv"
+    write_csv(
+        source,
+        [
+            {
+                "name": "Shenzhen Future Robotics Co., Ltd.",
+                "credit_code": "91440300MA5FUTURE1",
+                "registered_address": "Nanshan, Shenzhen",
+                "industry": "Robotics",
+                "notes": "priority",
+            }
+        ],
+    )
+
+    result = MasterListParser().parse(source)
+
+    snapshot = [
+        {
+            "row_number": row.row_number,
+            "name": row.name,
+            "credit_code": row.credit_code,
+            "registered_address": row.registered_address,
+            "industry": row.industry,
+            "extra_columns": row.extra_columns,
+        }
+        for row in result.rows
+    ]
+
+    assert snapshot == [
+        {
+            "row_number": 2,
+            "name": "Shenzhen Future Robotics Co., Ltd.",
+            "credit_code": "91440300MA5FUTURE1",
+            "registered_address": "Nanshan, Shenzhen",
+            "industry": "Robotics",
+            "extra_columns": {"notes": "priority"},
+        }
+    ]
+
+
+def test_parser_rejects_unsupported_file_format(tmp_path: Path) -> None:
+    source = tmp_path / "companies.json"
+    source.write_text("[]", encoding="utf-8")
+
+    try:
+        MasterListParser().parse(source)
+    except ValueError as exc:
+        assert "unsupported master list format" in str(exc)
+    else:
+        raise AssertionError("expected unsupported format to raise ValueError")

--- a/apps/company-data-agent/uv.lock
+++ b/apps/company-data-agent/uv.lock
@@ -25,6 +25,7 @@ name = "company-data-agent"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "openpyxl" },
     { name = "pydantic" },
 ]
 
@@ -34,10 +35,22 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "pydantic", specifier = ">=2.11.7" }]
+requires-dist = [
+    { name = "openpyxl", specifier = ">=3.1.5" },
+    { name = "pydantic", specifier = ">=2.11.7" },
+]
 
 [package.metadata.requires-dev]
 dev = [{ name = "pytest", specifier = ">=8.4.1" }]
+
+[[package]]
+name = "et-xmlfile"
+version = "2.0.0"
+source = { registry = "https://mirrors.sustech.edu.cn/pypi/web/simple" }
+sdist = { url = "https://mirrors.sustech.edu.cn/pypi/web/packages/d3/38/af70d7ab1ae9d4da450eeec1fa3918940a5fafb9055e934af8d6eb0c2313/et_xmlfile-2.0.0.tar.gz", hash = "sha256:dab3f4764309081ce75662649be815c4c9081e88f0837825f90fd28317d4da54" }
+wheels = [
+    { url = "https://mirrors.sustech.edu.cn/pypi/web/packages/c1/8b/5fe2cc11fee489817272089c4203e679c63b570a5aaeb18d852ae3cbba6a/et_xmlfile-2.0.0-py3-none-any.whl", hash = "sha256:7a91720bc756843502c3b7504c77b8fe44217c85c537d85037f0f536151b2caa" },
+]
 
 [[package]]
 name = "iniconfig"
@@ -46,6 +59,18 @@ source = { registry = "https://mirrors.sustech.edu.cn/pypi/web/simple" }
 sdist = { url = "https://mirrors.sustech.edu.cn/pypi/web/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730" }
 wheels = [
     { url = "https://mirrors.sustech.edu.cn/pypi/web/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12" },
+]
+
+[[package]]
+name = "openpyxl"
+version = "3.1.5"
+source = { registry = "https://mirrors.sustech.edu.cn/pypi/web/simple" }
+dependencies = [
+    { name = "et-xmlfile" },
+]
+sdist = { url = "https://mirrors.sustech.edu.cn/pypi/web/packages/3d/f9/88d94a75de065ea32619465d2f77b29a0469500e99012523b91cc4141cd1/openpyxl-3.1.5.tar.gz", hash = "sha256:cf0e3cf56142039133628b5acffe8ef0c12bc902d2aadd3e0fe5878dc08d1050" }
+wheels = [
+    { url = "https://mirrors.sustech.edu.cn/pypi/web/packages/c0/da/977ded879c29cbd04de313843e76868e6e13408a94ed6b987245dc7c8506/openpyxl-3.1.5-py2.py3-none-any.whl", hash = "sha256:5282c12b107bffeef825f4617dc029afaf41d0ea60823bbb665ef3079dc79de2" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #11

## Summary
- adds a real master-list parser that reads Shenzhen company inputs from CSV and Excel files
- emits normalized row objects plus row-level structured parse errors without aborting valid rows
- supports header alias mapping, blank-row skipping, extra-column preservation, and unsupported-format rejection
- includes a Chinese usage and verification document for the parser

## Audit Trail
- Kept parsing separate from identity generation, deduplication, and persistence so downstream issues can consume one reusable row stream without reparsing files.
- Used explicit row/result/error models to preserve provenance and make later import reporting deterministic.
- Added header alias normalization to tolerate common Chinese and English source column variants while keeping one canonical downstream shape.
- This issue is ingestion-layer parsing only, so no x86_64 SIMD optimizations, Linux-specific syscalls, or memory-alignment strategies were implemented here.

## Verification
- `UV_CACHE_DIR=.uv-cache uv run pytest`
