### PR TITLE
feat: add canonical company identity rules for issue #12

### DIFF
--- a/apps/company-data-agent/README.md
+++ b/apps/company-data-agent/README.md
@@ -7,3 +7,4 @@
 - [Issue 9 实现说明](docs/issue-9-公司记录模型说明.md)
 - [Issue 10 配置与路径约定说明](docs/issue-10-配置与路径约定说明.md)
 - [Issue 11 主数据表解析说明](docs/issue-11-主数据表解析说明.md)
+- [Issue 12 企业 identity 说明](docs/issue-12-company-identity-说明.md)

--- a/apps/company-data-agent/docs/issue-12-company-identity-说明.md
+++ b/apps/company-data-agent/docs/issue-12-company-identity-说明.md
@@ -1,0 +1,179 @@
+# Issue 12 实现说明：企业信用代码规范化与稳定 ID 生成
+
+本文档说明 `Issue #12` 已完成的内容，包括：
+
+1. 实现了什么
+2. 如何使用
+3. 如何验证
+
+核心代码位于：
+
+- `src/company_data_agent/identity/company_identity.py`
+- `tests/test_company_identity.py`
+
+---
+
+## 一、这次实现了什么
+
+这次实现把企业 identity 规则从分散的字段校验提升成了一个可复用模块，解决三件事：
+
+- 原始 `credit_code` 的规范化
+- 规范化后的 `credit_code` 校验
+- 稳定 `company_id` 生成
+
+### 1. 规范化 `credit_code`
+
+当前 `normalize_credit_code()` 会：
+
+- 去掉首尾空白
+- 转为大写
+- 去掉展示层噪声中的空格和连字符 `-`
+
+例如：
+
+```python
+normalize_credit_code(" 9144 0300-ma5future1 ")
+```
+
+结果为：
+
+```python
+"91440300MA5FUTURE1"
+```
+
+### 2. 明确校验规则
+
+规范化之后，`credit_code` 必须满足：
+
+- 长度为 18
+- 只能包含 `0-9A-Z`
+
+不满足时立即抛错，而不是把坏 identity 带到去重、增强或入库阶段。
+
+### 3. 生成稳定 `company_id`
+
+当前 `company_id` 生成算法是：
+
+```text
+COMP-{SHA256(normalized_credit_code)[:20]}
+```
+
+以 `91440300MA5FUTURE1` 为例，当前生成结果为：
+
+```text
+COMP-9A0B2B5AB656D527B267
+```
+
+这个算法的设计目标是：
+
+- 同一个 `credit_code` 永远生成同一个 `company_id`
+- 不依赖外部 provider
+- 在重跑、增量更新、并行任务中保持稳定
+
+### 4. 提供统一入口 `CompanyIdentity`
+
+为了让后续模块更容易使用，这次提供了：
+
+```python
+CompanyIdentity.from_raw_credit_code(...)
+```
+
+它会一次完成：
+
+- 规范化
+- 校验
+- `company_id` 生成
+
+这样后续 `#13` 不需要自己拼三步逻辑。
+
+---
+
+## 二、怎么使用
+
+### 1. 只做 `credit_code` 规范化
+
+```python
+from company_data_agent.identity import normalize_credit_code
+
+normalized = normalize_credit_code(" 9144 0300-ma5future1 ")
+```
+
+### 2. 直接生成稳定 `company_id`
+
+```python
+from company_data_agent.identity import generate_company_id
+
+company_id = generate_company_id("91440300MA5FUTURE1")
+```
+
+### 3. 一步得到完整 identity
+
+```python
+from company_data_agent.identity import CompanyIdentity
+
+identity = CompanyIdentity.from_raw_credit_code(" 91440300ma5future1 ")
+
+print(identity.credit_code)
+print(identity.company_id)
+```
+
+### 4. 当前 `CompanyRecord` 也已接入这套规则
+
+这次还把 `CompanyRecord` 中的 `credit_code` 与 `id` 校验接到了共享 identity 规则上，所以：
+
+- `credit_code` 会按统一规则规范化
+- `id` 必须符合 canonical `company_id` 格式
+
+这避免了 identity 规则在 model 和 importer 两边各写一套。
+
+---
+
+## 三、怎么验证
+
+### 1. 自动化测试
+
+新增了 `test_company_identity.py`，覆盖：
+
+- 大小写、空格、连字符等展示噪声
+- 长度错误和非法字符
+- `company_id` 快照稳定性
+- canonical ID 格式校验
+- `CompanyIdentity.from_raw_credit_code()` 一步生成
+
+运行方式：
+
+```bash
+UV_CACHE_DIR=.uv-cache uv run pytest
+```
+
+### 2. 当前验证结果
+
+当前 package 全量结果应为：
+
+```text
+27 passed
+```
+
+其中包括：
+
+- `#9` 的 record model 测试
+- `#10` 的 config contract 测试
+- `#11` 的 master-list parser 测试
+- `#12` 的 identity 测试
+
+---
+
+## 四、对后续任务的直接价值
+
+`#12` 完成后，后续模块已经有统一 identity 入口：
+
+- `#13`
+  可直接用来生成 skeleton 记录的 `id`
+
+- `#14/#15`
+  可复用规范化后的 `credit_code` 作为 provider 查询 key
+
+- `#22/#23`
+  可保证持久化与报表中的 company identity 稳定不漂移
+
+这一步的意义在于，后续所有真正的采集和增强逻辑都能围绕同一套 identity 规则工作，而不是各自定义“什么叫同一家公司”。

--- a/apps/company-data-agent/docs/issue-9-公司记录模型说明.md
+++ b/apps/company-data-agent/docs/issue-9-公司记录模型说明.md
@@ -150,11 +150,12 @@ record = PartialCompanyRecord.model_validate(
 ```python
 from datetime import UTC, datetime
 
+from company_data_agent.identity import generate_company_id
 from company_data_agent.models.company_record import CompanySource, FinalCompanyRecord
 
 record = FinalCompanyRecord.model_validate(
     {
-        "id": "COMP-91440300MA5FUTURE1",
+        "id": generate_company_id("91440300MA5FUTURE1"),
         "name": "深圳未来机器人有限公司",
         "credit_code": "91440300MA5FUTURE1",
         "profile_summary": "一家聚焦手术机器人与智能控制系统的深圳科技企业，面向医院与科研机构提供核心机器人平台能力。",

--- a/apps/company-data-agent/src/company_data_agent/__init__.py
+++ b/apps/company-data-agent/src/company_data_agent/__init__.py
@@ -10,6 +10,12 @@ from company_data_agent.config import (
     PostgresConfig,
     QimingpianConfig,
 )
+from company_data_agent.identity import (
+    CompanyIdentity,
+    generate_company_id,
+    normalize_credit_code,
+    validate_company_id,
+)
 from company_data_agent.ingest import (
     MasterListParseError,
     MasterListParseResult,
@@ -27,19 +33,23 @@ from company_data_agent.models.company_record import (
 __all__ = [
     "CompanySource",
     "CompanyDataAgentConfig",
+    "CompanyIdentity",
     "CrawlConfig",
     "EducationRecord",
     "EmbeddingConfig",
     "EnvVarRef",
     "FinalCompanyRecord",
+    "generate_company_id",
     "MasterListParseError",
     "MasterListParseResult",
     "MasterListParser",
     "KeyPersonnelRecord",
     "LLMConfig",
+    "normalize_credit_code",
     "PartialCompanyRecord",
     "ParsedMasterListRow",
     "PostgresConfig",
     "QimingpianConfig",
+    "validate_company_id",
     "ArtifactLayout",
 ]

--- a/apps/company-data-agent/src/company_data_agent/identity/__init__.py
+++ b/apps/company-data-agent/src/company_data_agent/identity/__init__.py
@@ -1,0 +1,15 @@
+"""Canonical company identity normalization and ID generation."""
+
+from company_data_agent.identity.company_identity import (
+    CompanyIdentity,
+    generate_company_id,
+    normalize_credit_code,
+    validate_company_id,
+)
+
+__all__ = [
+    "CompanyIdentity",
+    "generate_company_id",
+    "normalize_credit_code",
+    "validate_company_id",
+]

--- a/apps/company-data-agent/src/company_data_agent/identity/company_identity.py
+++ b/apps/company-data-agent/src/company_data_agent/identity/company_identity.py
@@ -1,0 +1,58 @@
+"""Canonical credit-code normalization and deterministic company ID generation."""
+
+from __future__ import annotations
+
+import hashlib
+import re
+
+from pydantic import BaseModel, ConfigDict, Field
+
+_CREDIT_CODE_PATTERN = re.compile(r"^[0-9A-Z]{18}$")
+_COMPANY_ID_PATTERN = re.compile(r"^COMP-[0-9A-F]{20}$")
+
+
+def normalize_credit_code(raw_credit_code: str) -> str:
+    """Normalize a raw credit code by removing presentation noise and validating it."""
+
+    stripped = "".join(
+        char for char in raw_credit_code.strip().upper() if not char.isspace() and char != "-"
+    )
+    if not _CREDIT_CODE_PATTERN.fullmatch(stripped):
+        raise ValueError("credit_code must normalize to an 18-character uppercase alphanumeric string")
+    return stripped
+
+
+def generate_company_id(raw_credit_code: str) -> str:
+    """Generate a deterministic company ID from a normalized credit code."""
+
+    normalized_credit_code = normalize_credit_code(raw_credit_code)
+    digest = hashlib.sha256(normalized_credit_code.encode("utf-8")).hexdigest().upper()[:20]
+    return f"COMP-{digest}"
+
+
+def validate_company_id(company_id: str) -> str:
+    """Validate the canonical company ID format."""
+
+    normalized = company_id.strip().upper()
+    if not _COMPANY_ID_PATTERN.fullmatch(normalized):
+        raise ValueError(
+            "company id must match the canonical format COMP-{20 uppercase hex chars}"
+        )
+    return normalized
+
+
+class CompanyIdentity(BaseModel):
+    """Canonical normalized company identity used before deduplication and enrichment."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    credit_code: str = Field(min_length=18, max_length=18)
+    company_id: str = Field(min_length=25, max_length=25)
+
+    @classmethod
+    def from_raw_credit_code(cls, raw_credit_code: str) -> "CompanyIdentity":
+        normalized_credit_code = normalize_credit_code(raw_credit_code)
+        return cls(
+            credit_code=normalized_credit_code,
+            company_id=generate_company_id(normalized_credit_code),
+        )

--- a/apps/company-data-agent/src/company_data_agent/models/company_record.py
+++ b/apps/company-data-agent/src/company_data_agent/models/company_record.py
@@ -8,6 +8,8 @@ from math import isfinite
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
+from company_data_agent.identity import normalize_credit_code, validate_company_id
+
 
 class CompanySource(StrEnum):
     """Known upstream sources for company data provenance."""
@@ -82,17 +84,12 @@ class CompanyRecordBase(BaseModel):
     def validate_company_id(cls, value: str | None) -> str | None:
         if value is None:
             return value
-        if not value.startswith("COMP-") or len(value) <= len("COMP-"):
-            raise ValueError("company id must start with 'COMP-' and include a suffix")
-        return value
+        return validate_company_id(value)
 
     @field_validator("credit_code")
     @classmethod
     def validate_credit_code(cls, value: str) -> str:
-        normalized = value.strip().upper()
-        if len(normalized) != 18 or not normalized.isalnum():
-            raise ValueError("credit_code must be an 18-character alphanumeric string")
-        return normalized
+        return normalize_credit_code(value)
 
     @field_validator("sources")
     @classmethod

--- a/apps/company-data-agent/tests/test_company_identity.py
+++ b/apps/company-data-agent/tests/test_company_identity.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import pytest
+
+from company_data_agent.identity import (
+    CompanyIdentity,
+    generate_company_id,
+    normalize_credit_code,
+    validate_company_id,
+)
+
+
+@pytest.mark.parametrize(
+    ("raw_credit_code", "expected"),
+    [
+        ("91440300MA5FUTURE1", "91440300MA5FUTURE1"),
+        (" 91440300ma5future1 ", "91440300MA5FUTURE1"),
+        ("9144 0300-MA5FUTURE1", "91440300MA5FUTURE1"),
+    ],
+)
+def test_normalize_credit_code_removes_presentation_noise(
+    raw_credit_code: str,
+    expected: str,
+) -> None:
+    assert normalize_credit_code(raw_credit_code) == expected
+
+
+@pytest.mark.parametrize(
+    "raw_credit_code",
+    [
+        "",
+        "91440300MA5FUTURE",
+        "91440300MA5FUTURE12",
+        "91440300MA5FUTURE!",
+        "91中文0300MA5FUTURE1",
+    ],
+)
+def test_invalid_credit_codes_are_rejected(raw_credit_code: str) -> None:
+    with pytest.raises(ValueError, match="credit_code"):
+        normalize_credit_code(raw_credit_code)
+
+
+def test_generate_company_id_is_deterministic_snapshot() -> None:
+    assert generate_company_id("91440300MA5FUTURE1") == "COMP-9A0B2B5AB656D527B267"
+    assert generate_company_id(" 91440300ma5future1 ") == "COMP-9A0B2B5AB656D527B267"
+
+
+def test_validate_company_id_accepts_canonical_format() -> None:
+    assert validate_company_id("COMP-9A0B2B5AB656D527B267") == "COMP-9A0B2B5AB656D527B267"
+
+
+def test_validate_company_id_rejects_invalid_format() -> None:
+    with pytest.raises(ValueError, match="canonical format"):
+        validate_company_id("COMP-91440300MA5FUTURE1")
+
+
+def test_company_identity_from_raw_credit_code() -> None:
+    identity = CompanyIdentity.from_raw_credit_code(" 91440300ma5future1 ")
+
+    assert identity.credit_code == "91440300MA5FUTURE1"
+    assert identity.company_id == "COMP-9A0B2B5AB656D527B267"

--- a/apps/company-data-agent/tests/test_company_record.py
+++ b/apps/company-data-agent/tests/test_company_record.py
@@ -5,6 +5,7 @@ from datetime import UTC, datetime
 import pytest
 from pydantic import ValidationError
 
+from company_data_agent.identity import generate_company_id
 from company_data_agent.models.company_record import (
     CompanySource,
     FinalCompanyRecord,
@@ -25,7 +26,7 @@ def build_partial(**overrides: object) -> PartialCompanyRecord:
 
 def build_final(**overrides: object) -> FinalCompanyRecord:
     payload = {
-        "id": "COMP-91440300MA5FUTURE1",
+        "id": generate_company_id("91440300MA5FUTURE1"),
         "name": "深圳未来机器人有限公司",
         "credit_code": "91440300MA5FUTURE1",
         "profile_summary": "一家聚焦手术机器人与智能控制系统的深圳科技企业，面向医院与科研机构提供核心机器人平台能力。",
@@ -50,7 +51,7 @@ def test_partial_record_accepts_minimal_valid_payload() -> None:
 def test_final_record_requires_final_invariants() -> None:
     record = build_final(sources=[CompanySource.MASTER_LIST, CompanySource.WEBSITE, CompanySource.MASTER_LIST])
 
-    assert record.id == "COMP-91440300MA5FUTURE1"
+    assert record.id == generate_company_id("91440300MA5FUTURE1")
     assert record.sources == [CompanySource.MASTER_LIST, CompanySource.WEBSITE]
     assert record.profile_embedding == [0.1, 0.2, 0.3]
 
@@ -61,7 +62,7 @@ def test_invalid_credit_code_is_rejected() -> None:
 
 
 def test_invalid_company_id_is_rejected() -> None:
-    with pytest.raises(ValidationError, match="company id"):
+    with pytest.raises(ValidationError, match="canonical format"):
         build_final(id="BAD-91440300MA5FUTURE1")
 
 


### PR DESCRIPTION
Closes #12

## Summary
- adds a shared identity module for credit-code normalization, canonical company ID validation, and deterministic company ID generation
- defines the stable company ID algorithm as `COMP-{SHA256(normalized_credit_code)[:20]}` and exposes a one-step `CompanyIdentity.from_raw_credit_code(...)` entrypoint
- wires company record validation onto the shared identity rules so model validation and downstream importer logic stay aligned
- includes a Chinese usage and verification document for the identity contract

## Audit Trail
- Centralized identity handling in one module to avoid parser, model, importer, and persistence code each inventing their own cleanup or ID-generation rules.
- Chose a truncated uppercase SHA-256 digest for `company_id` so the identifier is deterministic, compact, and provider-independent while still remaining collision-resistant for this dataset scale.
- Kept normalization limited to presentation noise removal (whitespace and hyphens) rather than silently dropping arbitrary characters, so genuinely malformed credit codes still fail fast.
- This issue is identity normalization only, so no x86_64 SIMD optimizations, Linux-specific syscalls, or memory-alignment strategies were implemented here.

## Verification
- `UV_CACHE_DIR=.uv-cache uv run pytest`
