### PR TITLE
feat: add skeleton import stage for issue #13

### DIFF
--- a/apps/company-data-agent/README.md
+++ b/apps/company-data-agent/README.md
@@ -8,3 +8,4 @@
 - [Issue 10 配置与路径约定说明](docs/issue-10-配置与路径约定说明.md)
 - [Issue 11 主数据表解析说明](docs/issue-11-主数据表解析说明.md)
 - [Issue 12 企业 identity 说明](docs/issue-12-company-identity-说明.md)
+- [Issue 13 Skeleton 导入说明](docs/issue-13-skeleton-import-说明.md)

--- a/apps/company-data-agent/docs/issue-13-skeleton-import-说明.md
+++ b/apps/company-data-agent/docs/issue-13-skeleton-import-说明.md
@@ -1,0 +1,234 @@
+# Issue 13 实现说明：Skeleton 导入与导入报告
+
+本文档说明 `Issue #13` 已完成的内容，包括：
+
+1. 实现了什么
+2. 如何使用
+3. 如何验证
+
+核心代码位于：
+
+- `src/company_data_agent/importer/skeleton_import.py`
+- `tests/test_skeleton_import.py`
+
+---
+
+## 一、这次实现了什么
+
+这次实现把前面三层能力真正接起来了：
+
+- `#11` 的主数据表解析结果
+- `#12` 的 identity 规则
+- `#9` 的企业记录模型
+
+最终产出的是：
+
+- dedup 后的 skeleton company records
+- 稳定的导入报告
+
+### 1. 把解析行变成 skeleton records
+
+`SkeletonImporter` 会把 `MasterListParseResult.rows` 转成 `PartialCompanyRecord`，并为每家公司补齐：
+
+- `id`
+- `credit_code`
+- `name`
+- `registered_address`
+- `industry`
+- `sources`
+- `raw_data_path`
+
+这意味着从 `#13` 开始，主数据表不再只是“解析出来的行”，而是已经进入公司记录体系。
+
+### 2. 按规范化后的 `credit_code` 去重
+
+导入阶段的 distinct key 是规范化后的 `credit_code`。
+
+如果同一批输入里出现同一家公司多行，当前实现会：
+
+- 聚合同一个 identity
+- 按稳定规则合并字段
+- 只产出一条 skeleton record
+
+### 3. 支持和已有记录做 deterministic merge
+
+如果导入时传入 `existing_records`，当前实现会：
+
+- 以已有记录为 baseline
+- 用主数据表的非空基础字段覆盖 `name` / `registered_address` / `industry`
+- 保留已有记录中不属于主数据表的其他字段
+- 合并 `sources`
+
+这样后续增量导入不会把已有 skeleton / enrichment 信息误清空。
+
+### 4. 导入报告不再是口头描述，而是代码产物
+
+当前会生成：
+
+- `created_count`
+- `updated_count`
+- `skipped_count`
+- `failed_count`
+- `actions`
+- `failures`
+
+也就是说 docs / PRD 里提到的：
+
+```text
+新增 N 条、更新 N 条、失败 N 条
+```
+
+现在已经有了实际实现。
+
+### 5. 行级错误继续保留，不中断成功导入
+
+解析阶段遗留下来的 `MasterListParseError` 会进入最终导入报告。
+
+另外，如果某一行在导入阶段才暴露出 identity 问题，比如：
+
+- `credit_code` 非法
+
+也会被记录为失败，而不是让整批导入中止。
+
+---
+
+## 二、怎么使用
+
+### 1. 基础用法
+
+```python
+from company_data_agent.config import ArtifactLayout
+from company_data_agent.importer import SkeletonImporter
+from company_data_agent.ingest import MasterListParser
+
+parser = MasterListParser()
+parse_result = parser.parse("data/shenzhen_company_list.xlsx")
+
+layout = ArtifactLayout.model_validate({"root_dir": "artifacts/company-data-agent"})
+
+result = SkeletonImporter().import_rows(parse_result, layout)
+```
+
+### 2. 获取 skeleton records
+
+```python
+for record in result.records:
+    print(record.id, record.name, record.credit_code)
+```
+
+### 3. 获取导入报告
+
+```python
+report = result.report
+
+print(report.created_count)
+print(report.updated_count)
+print(report.skipped_count)
+print(report.failed_count)
+```
+
+### 4. 传入已有记录做 merge
+
+```python
+result = SkeletonImporter().import_rows(
+    parse_result,
+    layout,
+    existing_records=existing_records,
+)
+```
+
+这适用于：
+
+- 月度重跑
+- 增量导入
+- 已有 skeleton 记录更新
+
+---
+
+## 三、合并规则
+
+当前实现的 merge 规则是稳定且显式的：
+
+### 1. identity
+
+- 统一使用 `#12` 的 `normalize_credit_code()`
+- `id` 使用 `generate_company_id()`
+
+### 2. 基础字段覆盖
+
+主数据表当前负责的基础字段是：
+
+- `name`
+- `registered_address`
+- `industry`
+
+只要新输入中该字段非空，且与 baseline 不同，就会覆盖。
+
+### 3. provenance
+
+- `sources` 会确保包含 `master_list`
+- `raw_data_path` 使用 deterministic path
+
+### 4. 非主表字段保留
+
+例如已有记录里的：
+
+- `website`
+- 其他后续 enrichment 字段
+
+不会被 skeleton import 清空。
+
+---
+
+## 四、怎么验证
+
+### 1. 自动化测试
+
+当前新增 `test_skeleton_import.py`，覆盖：
+
+- 新记录创建
+- 批内重复 `credit_code` 去重与合并
+- 既有记录更新
+- 既有记录无变化时的 skip
+- 失败行计数
+- 重跑结果稳定
+- 非法 `credit_code` 变成 failure
+
+运行方式：
+
+```bash
+UV_CACHE_DIR=.uv-cache uv run pytest
+```
+
+### 2. 当前验证结果
+
+当前 package 全量结果应为：
+
+```text
+38 passed
+```
+
+包含：
+
+- `#9` record model
+- `#10` config contract
+- `#11` master-list parser
+- `#12` company identity
+- `#13` skeleton import
+
+---
+
+## 五、对后续任务的直接价值
+
+`#13` 完成后，后续能力已经有真实输入：
+
+- `#14/#15`
+  可以直接基于 skeleton records 做 Qimingpian 增强
+
+- `#17/#18/#19`
+  可以围绕已确定的 base company records 做 source discovery、抽取和 summary
+
+- `#23`
+  可以直接消费导入报告做 run reporting
+
+换句话说，从这一步开始，企业主数据表已经不只是被“读进来”，而是已经进入了可追踪、可报告、可继续增强的 skeleton 数据形态。

--- a/apps/company-data-agent/src/company_data_agent/__init__.py
+++ b/apps/company-data-agent/src/company_data_agent/__init__.py
@@ -16,6 +16,13 @@ from company_data_agent.identity import (
     normalize_credit_code,
     validate_company_id,
 )
+from company_data_agent.importer import (
+    SkeletonImportAction,
+    SkeletonImportActionType,
+    SkeletonImportReport,
+    SkeletonImportResult,
+    SkeletonImporter,
+)
 from company_data_agent.ingest import (
     MasterListParseError,
     MasterListParseResult,
@@ -50,6 +57,11 @@ __all__ = [
     "ParsedMasterListRow",
     "PostgresConfig",
     "QimingpianConfig",
+    "SkeletonImportAction",
+    "SkeletonImportActionType",
+    "SkeletonImportReport",
+    "SkeletonImportResult",
+    "SkeletonImporter",
     "validate_company_id",
     "ArtifactLayout",
 ]

--- a/apps/company-data-agent/src/company_data_agent/importer/__init__.py
+++ b/apps/company-data-agent/src/company_data_agent/importer/__init__.py
@@ -1,0 +1,17 @@
+"""Skeleton import stage for company master-list ingestion."""
+
+from company_data_agent.importer.skeleton_import import (
+    SkeletonImportAction,
+    SkeletonImportActionType,
+    SkeletonImportReport,
+    SkeletonImportResult,
+    SkeletonImporter,
+)
+
+__all__ = [
+    "SkeletonImportAction",
+    "SkeletonImportActionType",
+    "SkeletonImportReport",
+    "SkeletonImportResult",
+    "SkeletonImporter",
+]

--- a/apps/company-data-agent/src/company_data_agent/importer/skeleton_import.py
+++ b/apps/company-data-agent/src/company_data_agent/importer/skeleton_import.py
@@ -1,0 +1,230 @@
+"""Skeleton import stage that deduplicates master-list rows and emits import reports."""
+
+from __future__ import annotations
+
+from collections import OrderedDict
+from enum import StrEnum
+from pathlib import Path
+from typing import Iterable
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from company_data_agent.config import ArtifactLayout
+from company_data_agent.identity import CompanyIdentity, normalize_credit_code
+from company_data_agent.ingest import (
+    MasterListParseError,
+    MasterListParseResult,
+    ParsedMasterListRow,
+)
+from company_data_agent.models.company_record import CompanySource, PartialCompanyRecord
+
+
+class SkeletonImportActionType(StrEnum):
+    """Final disposition for a distinct company identity in the import batch."""
+
+    CREATED = "created"
+    UPDATED = "updated"
+    SKIPPED = "skipped"
+
+
+class SkeletonImportAction(BaseModel):
+    """Per-company summary emitted by the skeleton import stage."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    action: SkeletonImportActionType
+    company_id: str
+    credit_code: str
+    row_numbers: list[int]
+    source_path: str
+
+
+class SkeletonImportReport(BaseModel):
+    """Deterministic import report for one parsed master-list input."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    source_path: str
+    processed_rows: int
+    distinct_companies: int
+    created_count: int
+    updated_count: int
+    skipped_count: int
+    failed_count: int
+    actions: list[SkeletonImportAction]
+    failures: list[MasterListParseError]
+
+
+class SkeletonImportResult(BaseModel):
+    """Skeleton records plus the deterministic import report."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    records: list[PartialCompanyRecord]
+    report: SkeletonImportReport
+
+
+class _AggregatedImportState(BaseModel):
+    """Internal aggregate state for one normalized credit code."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    baseline: PartialCompanyRecord | None
+    current: PartialCompanyRecord
+    row_numbers: list[int]
+    source_path: str
+
+
+class SkeletonImporter:
+    """Merge parsed master-list rows into base company records and a deterministic report."""
+
+    def import_rows(
+        self,
+        parse_result: MasterListParseResult,
+        artifact_layout: ArtifactLayout,
+        existing_records: Iterable[PartialCompanyRecord] | None = None,
+    ) -> SkeletonImportResult:
+        existing_by_credit = OrderedDict()
+        for record in sorted(existing_records or [], key=lambda item: item.credit_code):
+            existing_by_credit[normalize_credit_code(record.credit_code)] = record
+
+        failures: list[MasterListParseError] = list(parse_result.errors)
+        aggregated: OrderedDict[str, _AggregatedImportState] = OrderedDict()
+
+        for row in parse_result.rows:
+            try:
+                identity = CompanyIdentity.from_raw_credit_code(row.credit_code)
+                candidate = self._candidate_record(row, identity, artifact_layout)
+            except ValueError as exc:
+                failures.append(
+                    MasterListParseError(
+                        row_number=row.row_number,
+                        source_path=row.source_path,
+                        message=str(exc),
+                        raw_columns=row.raw_columns,
+                    )
+                )
+                continue
+
+            if identity.credit_code not in aggregated:
+                baseline = existing_by_credit.get(identity.credit_code)
+                merged = self._merge_records(baseline, candidate)
+                aggregated[identity.credit_code] = _AggregatedImportState(
+                    baseline=baseline,
+                    current=merged,
+                    row_numbers=[row.row_number],
+                    source_path=row.source_path,
+                )
+                continue
+
+            state = aggregated[identity.credit_code]
+            state.current = self._merge_records(state.current, candidate)
+            state.row_numbers.append(row.row_number)
+
+        actions: list[SkeletonImportAction] = []
+        records: list[PartialCompanyRecord] = []
+        created_count = 0
+        updated_count = 0
+        skipped_count = 0
+
+        for credit_code in sorted(aggregated):
+            state = aggregated[credit_code]
+            records.append(state.current)
+            action_type = self._classify_action(state.baseline, state.current)
+            if action_type is SkeletonImportActionType.CREATED:
+                created_count += 1
+            elif action_type is SkeletonImportActionType.UPDATED:
+                updated_count += 1
+            else:
+                skipped_count += 1
+
+            actions.append(
+                SkeletonImportAction(
+                    action=action_type,
+                    company_id=state.current.id or "",
+                    credit_code=credit_code,
+                    row_numbers=state.row_numbers,
+                    source_path=state.source_path,
+                )
+            )
+
+        return SkeletonImportResult(
+            records=records,
+            report=SkeletonImportReport(
+                source_path=parse_result.source_path,
+                processed_rows=len(parse_result.rows),
+                distinct_companies=len(actions),
+                created_count=created_count,
+                updated_count=updated_count,
+                skipped_count=skipped_count,
+                failed_count=len(failures),
+                actions=actions,
+                failures=failures,
+            ),
+        )
+
+    def _candidate_record(
+        self,
+        row: ParsedMasterListRow,
+        identity: CompanyIdentity,
+        artifact_layout: ArtifactLayout,
+    ) -> PartialCompanyRecord:
+        filename = f"{Path(row.source_path).stem}-row-{row.row_number:06d}.json"
+        return PartialCompanyRecord.model_validate(
+            {
+                "id": identity.company_id,
+                "name": row.name,
+                "credit_code": identity.credit_code,
+                "registered_address": row.registered_address,
+                "industry": row.industry,
+                "sources": [CompanySource.MASTER_LIST],
+                "raw_data_path": str(
+                    artifact_layout.raw_payload_path(
+                        identity.credit_code,
+                        CompanySource.MASTER_LIST.value,
+                        filename,
+                    )
+                ),
+            }
+        )
+
+    def _merge_records(
+        self,
+        baseline: PartialCompanyRecord | None,
+        candidate: PartialCompanyRecord,
+    ) -> PartialCompanyRecord:
+        if baseline is None:
+            return candidate
+
+        data = baseline.model_dump(mode="python")
+
+        data["id"] = candidate.id
+        data["credit_code"] = candidate.credit_code
+
+        changed = False
+        for field in ("name", "registered_address", "industry"):
+            incoming = getattr(candidate, field)
+            if incoming and incoming != data.get(field):
+                data[field] = incoming
+                changed = True
+
+        merged_sources = [CompanySource.MASTER_LIST, *baseline.sources]
+        if list(dict.fromkeys(merged_sources)) != baseline.sources:
+            changed = True
+        data["sources"] = merged_sources
+
+        if changed or not baseline.raw_data_path:
+            data["raw_data_path"] = candidate.raw_data_path
+
+        return PartialCompanyRecord.model_validate(data)
+
+    def _classify_action(
+        self,
+        baseline: PartialCompanyRecord | None,
+        current: PartialCompanyRecord,
+    ) -> SkeletonImportActionType:
+        if baseline is None:
+            return SkeletonImportActionType.CREATED
+        if baseline.model_dump(mode="python") == current.model_dump(mode="python"):
+            return SkeletonImportActionType.SKIPPED
+        return SkeletonImportActionType.UPDATED

--- a/apps/company-data-agent/tests/test_skeleton_import.py
+++ b/apps/company-data-agent/tests/test_skeleton_import.py
@@ -1,0 +1,211 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from company_data_agent.config import ArtifactLayout
+from company_data_agent.importer import SkeletonImportActionType, SkeletonImporter
+from company_data_agent.identity import generate_company_id
+from company_data_agent.ingest import MasterListParseError, MasterListParseResult, ParsedMasterListRow
+from company_data_agent.models.company_record import CompanySource, PartialCompanyRecord
+
+
+def build_layout() -> ArtifactLayout:
+    return ArtifactLayout.model_validate({"root_dir": "artifacts/company-data-agent"})
+
+
+def build_row(
+    row_number: int,
+    *,
+    name: str,
+    credit_code: str,
+    registered_address: str | None = None,
+    industry: str | None = None,
+    source_path: str = "data/shenzhen_company_list.xlsx",
+) -> ParsedMasterListRow:
+    return ParsedMasterListRow(
+        row_number=row_number,
+        source_path=source_path,
+        raw_columns={
+            "企业名称": name,
+            "统一社会信用代码": credit_code,
+            "注册地址": registered_address,
+            "行业分类": industry,
+        },
+        name=name,
+        credit_code=credit_code,
+        registered_address=registered_address,
+        industry=industry,
+    )
+
+
+def build_parse_result(
+    rows: list[ParsedMasterListRow],
+    *,
+    errors: list[MasterListParseError] | None = None,
+    source_path: str = "data/shenzhen_company_list.xlsx",
+) -> MasterListParseResult:
+    return MasterListParseResult(
+        rows=rows,
+        errors=errors or [],
+        source_path=source_path,
+    )
+
+
+def test_skeleton_import_creates_deduplicated_records_and_report() -> None:
+    parse_result = build_parse_result(
+        [
+            build_row(
+                2,
+                name="深圳未来机器人有限公司",
+                credit_code="91440300MA5FUTURE1",
+                registered_address="深圳市南山区",
+            ),
+            build_row(
+                3,
+                name="深圳未来机器人有限公司",
+                credit_code="91440300MA5FUTURE1",
+                industry="机器人",
+            ),
+            build_row(
+                4,
+                name="深圳智算科技有限公司",
+                credit_code="91440300MA5INTELAI",
+                registered_address="深圳市福田区",
+                industry="人工智能",
+            ),
+        ]
+    )
+
+    result = SkeletonImporter().import_rows(parse_result, build_layout())
+
+    assert [record.credit_code for record in result.records] == [
+        "91440300MA5FUTURE1",
+        "91440300MA5INTELAI",
+    ]
+    assert result.records[0].id == generate_company_id("91440300MA5FUTURE1")
+    assert result.records[0].registered_address == "深圳市南山区"
+    assert result.records[0].industry == "机器人"
+    assert result.report.created_count == 2
+    assert result.report.updated_count == 0
+    assert result.report.skipped_count == 0
+    assert result.report.failed_count == 0
+    assert result.report.actions[0].row_numbers == [2, 3]
+    assert result.report.actions[0].action is SkeletonImportActionType.CREATED
+
+
+def test_skeleton_import_updates_existing_record_and_preserves_existing_fields() -> None:
+    existing = PartialCompanyRecord.model_validate(
+        {
+            "id": generate_company_id("91440300MA5FUTURE1"),
+            "name": "深圳未来机器人旧名称有限公司",
+            "credit_code": "91440300MA5FUTURE1",
+            "website": "https://future-robotics.example",
+            "sources": [CompanySource.WEBSITE],
+            "raw_data_path": "raw/previous.json",
+        }
+    )
+
+    parse_result = build_parse_result(
+        [
+            build_row(
+                2,
+                name="深圳未来机器人有限公司",
+                credit_code="91440300MA5FUTURE1",
+                registered_address="深圳市南山区",
+                industry="机器人",
+            )
+        ]
+    )
+
+    result = SkeletonImporter().import_rows(parse_result, build_layout(), existing_records=[existing])
+
+    record = result.records[0]
+    assert record.name == "深圳未来机器人有限公司"
+    assert record.website == "https://future-robotics.example"
+    assert record.sources == [CompanySource.MASTER_LIST, CompanySource.WEBSITE]
+    assert result.report.updated_count == 1
+    assert result.report.actions[0].action is SkeletonImportActionType.UPDATED
+
+
+def test_skeleton_import_skips_unchanged_existing_record_and_counts_failures() -> None:
+    existing = PartialCompanyRecord.model_validate(
+        {
+            "id": generate_company_id("91440300MA5FUTURE1"),
+            "name": "深圳未来机器人有限公司",
+            "credit_code": "91440300MA5FUTURE1",
+            "registered_address": "深圳市南山区",
+            "industry": "机器人",
+            "sources": [CompanySource.MASTER_LIST],
+            "raw_data_path": "artifacts/company-data-agent/raw/companies/91440300MA5FUTURE1/master_list/shenzhen_company_list-row-000002.json",
+        }
+    )
+    parse_result = build_parse_result(
+        [
+            build_row(
+                2,
+                name="深圳未来机器人有限公司",
+                credit_code="91440300MA5FUTURE1",
+                registered_address="深圳市南山区",
+                industry="机器人",
+            )
+        ],
+        errors=[
+            MasterListParseError(
+                row_number=3,
+                source_path="data/shenzhen_company_list.xlsx",
+                message="missing required columns: name",
+                raw_columns={"统一社会信用代码": "91440300MA5BROKEN01"},
+            )
+        ],
+    )
+
+    result = SkeletonImporter().import_rows(parse_result, build_layout(), existing_records=[existing])
+
+    assert result.report.created_count == 0
+    assert result.report.updated_count == 0
+    assert result.report.skipped_count == 1
+    assert result.report.failed_count == 1
+    assert result.report.actions[0].action is SkeletonImportActionType.SKIPPED
+    assert result.report.failures[0].row_number == 3
+
+
+def test_skeleton_import_is_deterministic_on_rerun() -> None:
+    parse_result = build_parse_result(
+        [
+            build_row(
+                2,
+                name="深圳未来机器人有限公司",
+                credit_code="91440300MA5FUTURE1",
+                registered_address="深圳市南山区",
+                industry="机器人",
+            )
+        ]
+    )
+
+    importer = SkeletonImporter()
+    first = importer.import_rows(parse_result, build_layout())
+    second = importer.import_rows(parse_result, build_layout())
+
+    assert [record.model_dump(mode="python") for record in first.records] == [
+        record.model_dump(mode="python") for record in second.records
+    ]
+    assert first.report.model_dump(mode="python") == second.report.model_dump(mode="python")
+
+
+def test_invalid_credit_code_from_parsed_row_becomes_failure() -> None:
+    parse_result = build_parse_result(
+        [
+            build_row(
+                2,
+                name="深圳未来机器人有限公司",
+                credit_code="bad-code",
+                registered_address="深圳市南山区",
+            )
+        ]
+    )
+
+    result = SkeletonImporter().import_rows(parse_result, build_layout())
+
+    assert not result.records
+    assert result.report.failed_count == 1
+    assert "credit_code" in result.report.failures[0].message


### PR DESCRIPTION
Closes #13

## Summary
- adds a skeleton import stage that converts parsed master-list rows into deduplicated base company records
- merges incoming master-list data onto existing skeleton records under deterministic field and provenance rules
- emits a deterministic import report with created, updated, skipped, and failed counts plus per-company actions and failure details
- includes a Chinese usage and verification document for the skeleton import stage

## Audit Trail
- Kept the importer separate from parser, identity normalization, and persistence so each stage can be validated independently and reused by later enrichment work.
- Chose normalized credit code as the deduplication key and stable action classification (`created` / `updated` / `skipped`) so import reports remain deterministic across reruns.
- Preserved existing non-master-list fields during merge while allowing master-list base fields to refresh, which keeps incremental imports from wiping downstream enrichment state.
- This issue is import-stage business logic only, so no x86_64 SIMD optimizations, Linux-specific syscalls, or memory-alignment strategies were implemented here.

## Verification
- `UV_CACHE_DIR=.uv-cache uv run pytest`
